### PR TITLE
[SERV-268] Add 'lib' directory to GA build cache

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,9 @@ jobs:
         uses: actions/cache@0781355a23dac32fd3bac414512f4b903437991a # v2
         if: ${{ env.MAVEN_CACHE_KEY }}
         with:
-          path: ~/.m2
+          path: |
+            ~/.m2
+            lib
           key: freelibrary-cache-${{ secrets.MAVEN_CACHE_KEY }}-${{ hashFiles('**/pom.xml') }}
           restore-keys: freelibrary-cache-${{ secrets.MAVEN_CACHE_KEY }}-
       - name: Install local dependencies


### PR DESCRIPTION
Add 'lib' directory to the cache that's preserved between GA builds.