### PR TITLE
[IIIF-1180] Handle Sinai image requests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
     <hauth.container.version>0.0.4</hauth.container.version>
     <psql.container.version>12.7-alpine</psql.container.version>
     <redis.container.version>6.2.5-alpine</redis.container.version>
-    <cantaloupe.container.version>nightly</cantaloupe.container.version>
+    <cantaloupe.container.version>5.0.4-1</cantaloupe.container.version>
 
     <!-- Build-time options -->
     <update.sql>false</update.sql>

--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
     <hauth.container.version>0.0.4</hauth.container.version>
     <psql.container.version>12.7-alpine</psql.container.version>
     <redis.container.version>6.2.5-alpine</redis.container.version>
-    <cantaloupe.container.version>5.0.4-1</cantaloupe.container.version>
+    <cantaloupe.container.version>nightly</cantaloupe.container.version>
 
     <!-- Build-time options -->
     <update.sql>false</update.sql>

--- a/src/main/java/edu/ucla/library/iiif/auth/delegate/CantaloupeAuthDelegate.java
+++ b/src/main/java/edu/ucla/library/iiif/auth/delegate/CantaloupeAuthDelegate.java
@@ -86,9 +86,10 @@ public class CantaloupeAuthDelegate extends GenericAuthDelegate implements JavaD
     private AccessMode myAccessMode;
 
     /**
-     * Whether or not it is unnecessary to include IIIF authentication services in the info.json response.
+     * If the current request is for info.json, whether or not a IIIF authentication service description should be
+     * included in the response.
      */
-    private boolean myClientAlreadyHasFullAccess = true;
+    private boolean myInfoJsonShouldContainAuth;
 
     /**
      * Creates a new Cantaloupe authorization delegate.
@@ -124,7 +125,7 @@ public class CantaloupeAuthDelegate extends GenericAuthDelegate implements JavaD
                 } else if (Arrays.equals(configuredScaleConstraint, scaleConstraint)) {
                     // Degraded image request for the size we allow access to
                     // (Probably via an earlier HTTP 302 redirect)
-                    myClientAlreadyHasFullAccess = false;
+                    myInfoJsonShouldContainAuth = true;
 
                     return true;
                 } else if (scaleConstraint[0] != scaleConstraint[1]) {
@@ -148,7 +149,7 @@ public class CantaloupeAuthDelegate extends GenericAuthDelegate implements JavaD
                             return true;
                         } else {
                             // No access
-                            myClientAlreadyHasFullAccess = false;
+                            myInfoJsonShouldContainAuth = true;
 
                             return Map.of(STATUS_CODE, Long.valueOf(HTTP.UNAUTHORIZED), //
                                     CHALLENGE, WWW_AUTHENTICATE_HEADER_VALUE);
@@ -191,10 +192,10 @@ public class CantaloupeAuthDelegate extends GenericAuthDelegate implements JavaD
      * @return A map of additional response keys
      */
     private Map<String, Object> getExtraInformationResponseKeys() {
-        if (myClientAlreadyHasFullAccess) {
-            return Collections.emptyMap();
-        } else {
+        if (myInfoJsonShouldContainAuth) {
             return Collections.singletonMap(JsonKeys.SERVICE, List.of(getAuthServices()));
+        } else {
+            return Collections.emptyMap();
         }
     }
 

--- a/src/test/java/edu/ucla/library/iiif/auth/delegate/CantaloupeAuthDelegateIT.java
+++ b/src/test/java/edu/ucla/library/iiif/auth/delegate/CantaloupeAuthDelegateIT.java
@@ -1,6 +1,10 @@
 
 package edu.ucla.library.iiif.auth.delegate;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
@@ -16,7 +20,6 @@ import java.util.Map;
 
 import org.apache.commons.io.FileUtils;
 
-import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;
 
@@ -388,8 +391,8 @@ public class CantaloupeAuthDelegateIT {
             final String expectedResponse =
                     getExpectedImageInfo(OPEN_ACCESS_IMAGE, FULL_ACCESS_RESPONSE_TEMPLATE_V2, 2);
 
-            Assert.assertEquals(HTTP.OK, response.statusCode());
-            Assert.assertTrue(TestUtils.responseHasContentType(response, MediaType.APPLICATION_JSON,
+            assertEquals(HTTP.OK, response.statusCode());
+            assertTrue(TestUtils.responseHasContentType(response, MediaType.APPLICATION_JSON,
                     MediaType.APPLICATION_LD_PLUS_JSON));
             TestUtils.assertEquals(expectedResponse, response.body());
         }
@@ -400,8 +403,8 @@ public class CantaloupeAuthDelegateIT {
             final String expectedResponse =
                     getExpectedImageInfo(TIERED_ACCESS_IMAGE, FULL_ACCESS_RESPONSE_TEMPLATE_V2, 2);
 
-            Assert.assertEquals(HTTP.OK, response.statusCode());
-            Assert.assertTrue(TestUtils.responseHasContentType(response, MediaType.APPLICATION_JSON,
+            assertEquals(HTTP.OK, response.statusCode());
+            assertTrue(TestUtils.responseHasContentType(response, MediaType.APPLICATION_JSON,
                     MediaType.APPLICATION_LD_PLUS_JSON));
             TestUtils.assertEquals(expectedResponse, response.body());
         }
@@ -412,8 +415,8 @@ public class CantaloupeAuthDelegateIT {
             final String expectedResponse =
                     getExpectedImageInfo(TIERED_ACCESS_IMAGE_DEGRADED_VALID, DEGRADED_ACCESS_RESPONSE_TEMPLATE_V2, 2);
 
-            Assert.assertEquals(HTTP.OK, response.statusCode());
-            Assert.assertTrue(TestUtils.responseHasContentType(response, MediaType.APPLICATION_JSON,
+            assertEquals(HTTP.OK, response.statusCode());
+            assertTrue(TestUtils.responseHasContentType(response, MediaType.APPLICATION_JSON,
                     MediaType.APPLICATION_LD_PLUS_JSON));
             TestUtils.assertEquals(expectedResponse, response.body());
         }
@@ -423,8 +426,8 @@ public class CantaloupeAuthDelegateIT {
             final HttpResponse<String> response =
                     sendImageInfoRequest(TIERED_ACCESS_IMAGE_DEGRADED_UNAVAILABLE, null, 2);
 
-            Assert.assertEquals(HTTP.FORBIDDEN, response.statusCode());
-            Assert.assertFalse(TestUtils.responseHasContentType(response, MediaType.APPLICATION_JSON,
+            assertEquals(HTTP.FORBIDDEN, response.statusCode());
+            assertFalse(TestUtils.responseHasContentType(response, MediaType.APPLICATION_JSON,
                     MediaType.APPLICATION_LD_PLUS_JSON));
         }
 
@@ -435,8 +438,8 @@ public class CantaloupeAuthDelegateIT {
             final String expectedResponse =
                     getExpectedImageInfo(ALL_OR_NOTHING_ACCESS_IMAGE, FULL_ACCESS_RESPONSE_TEMPLATE_V2, 2);
 
-            Assert.assertEquals(HTTP.OK, response.statusCode());
-            Assert.assertTrue(TestUtils.responseHasContentType(response, MediaType.APPLICATION_JSON,
+            assertEquals(HTTP.OK, response.statusCode());
+            assertTrue(TestUtils.responseHasContentType(response, MediaType.APPLICATION_JSON,
                     MediaType.APPLICATION_LD_PLUS_JSON));
             TestUtils.assertEquals(expectedResponse, response.body());
         }
@@ -447,8 +450,8 @@ public class CantaloupeAuthDelegateIT {
             final String expectedResponse =
                     getExpectedImageInfo(ALL_OR_NOTHING_ACCESS_IMAGE, NO_ACCESS_RESPONSE_TEMPLATE_V2, 2);
 
-            Assert.assertEquals(HTTP.UNAUTHORIZED, response.statusCode());
-            Assert.assertTrue(TestUtils.responseHasContentType(response, MediaType.APPLICATION_JSON,
+            assertEquals(HTTP.UNAUTHORIZED, response.statusCode());
+            assertTrue(TestUtils.responseHasContentType(response, MediaType.APPLICATION_JSON,
                     MediaType.APPLICATION_LD_PLUS_JSON));
             TestUtils.assertEquals(expectedResponse, response.body());
         }
@@ -465,8 +468,8 @@ public class CantaloupeAuthDelegateIT {
             final String expectedResponse =
                     getExpectedImageInfo(OPEN_ACCESS_IMAGE, FULL_ACCESS_RESPONSE_TEMPLATE_V3, 3);
 
-            Assert.assertEquals(HTTP.OK, response.statusCode());
-            Assert.assertTrue(TestUtils.responseHasContentType(response, MediaType.APPLICATION_JSON,
+            assertEquals(HTTP.OK, response.statusCode());
+            assertTrue(TestUtils.responseHasContentType(response, MediaType.APPLICATION_JSON,
                     MediaType.APPLICATION_LD_PLUS_JSON));
             TestUtils.assertEquals(expectedResponse, response.body());
         }
@@ -477,8 +480,8 @@ public class CantaloupeAuthDelegateIT {
             final String expectedResponse =
                     getExpectedImageInfo(TIERED_ACCESS_IMAGE, FULL_ACCESS_RESPONSE_TEMPLATE_V3, 3);
 
-            Assert.assertEquals(HTTP.OK, response.statusCode());
-            Assert.assertTrue(TestUtils.responseHasContentType(response, MediaType.APPLICATION_JSON,
+            assertEquals(HTTP.OK, response.statusCode());
+            assertTrue(TestUtils.responseHasContentType(response, MediaType.APPLICATION_JSON,
                     MediaType.APPLICATION_LD_PLUS_JSON));
             TestUtils.assertEquals(expectedResponse, response.body());
         }
@@ -489,8 +492,8 @@ public class CantaloupeAuthDelegateIT {
             final String expectedResponse =
                     getExpectedImageInfo(TIERED_ACCESS_IMAGE_DEGRADED_VALID, DEGRADED_ACCESS_RESPONSE_TEMPLATE_V3, 3);
 
-            Assert.assertEquals(HTTP.OK, response.statusCode());
-            Assert.assertTrue(TestUtils.responseHasContentType(response, MediaType.APPLICATION_JSON,
+            assertEquals(HTTP.OK, response.statusCode());
+            assertTrue(TestUtils.responseHasContentType(response, MediaType.APPLICATION_JSON,
                     MediaType.APPLICATION_LD_PLUS_JSON));
             TestUtils.assertEquals(expectedResponse, response.body());
         }
@@ -500,8 +503,8 @@ public class CantaloupeAuthDelegateIT {
             final HttpResponse<String> response =
                     sendImageInfoRequest(TIERED_ACCESS_IMAGE_DEGRADED_UNAVAILABLE, null, 3);
 
-            Assert.assertEquals(HTTP.FORBIDDEN, response.statusCode());
-            Assert.assertFalse(TestUtils.responseHasContentType(response, MediaType.APPLICATION_JSON,
+            assertEquals(HTTP.FORBIDDEN, response.statusCode());
+            assertFalse(TestUtils.responseHasContentType(response, MediaType.APPLICATION_JSON,
                     MediaType.APPLICATION_LD_PLUS_JSON));
         }
 
@@ -512,8 +515,8 @@ public class CantaloupeAuthDelegateIT {
             final String expectedResponse =
                     getExpectedImageInfo(ALL_OR_NOTHING_ACCESS_IMAGE, FULL_ACCESS_RESPONSE_TEMPLATE_V3, 3);
 
-            Assert.assertEquals(HTTP.OK, response.statusCode());
-            Assert.assertTrue(TestUtils.responseHasContentType(response, MediaType.APPLICATION_JSON,
+            assertEquals(HTTP.OK, response.statusCode());
+            assertTrue(TestUtils.responseHasContentType(response, MediaType.APPLICATION_JSON,
                     MediaType.APPLICATION_LD_PLUS_JSON));
             TestUtils.assertEquals(expectedResponse, response.body());
         }
@@ -524,8 +527,8 @@ public class CantaloupeAuthDelegateIT {
             final String expectedResponse =
                     getExpectedImageInfo(ALL_OR_NOTHING_ACCESS_IMAGE, NO_ACCESS_RESPONSE_TEMPLATE_V3, 3);
 
-            Assert.assertEquals(HTTP.UNAUTHORIZED, response.statusCode());
-            Assert.assertTrue(TestUtils.responseHasContentType(response, MediaType.APPLICATION_JSON,
+            assertEquals(HTTP.UNAUTHORIZED, response.statusCode());
+            assertTrue(TestUtils.responseHasContentType(response, MediaType.APPLICATION_JSON,
                     MediaType.APPLICATION_LD_PLUS_JSON));
             TestUtils.assertEquals(expectedResponse, response.body());
         }
@@ -541,9 +544,9 @@ public class CantaloupeAuthDelegateIT {
             final HttpResponse<byte[]> response = sendImageRequest(OPEN_ACCESS_IMAGE, null, 2);
             final byte[] expectedResponse = getExpectedImage(OPEN_ACCESS_IMAGE);
 
-            Assert.assertEquals(HTTP.OK, response.statusCode());
-            Assert.assertTrue(TestUtils.responseHasContentType(response, MediaType.IMAGE_TIFF));
-            Assert.assertTrue(Arrays.equals(expectedResponse, response.body()));
+            assertEquals(HTTP.OK, response.statusCode());
+            assertTrue(TestUtils.responseHasContentType(response, MediaType.IMAGE_TIFF));
+            assertTrue(Arrays.equals(expectedResponse, response.body()));
         }
 
         @Override
@@ -574,17 +577,17 @@ public class CantaloupeAuthDelegateIT {
             final HttpResponse<byte[]> response = sendImageRequest(ALL_OR_NOTHING_ACCESS_IMAGE, cookieHeader, 2);
             final byte[] expectedResponse = getExpectedImage(ALL_OR_NOTHING_ACCESS_IMAGE);
 
-            Assert.assertEquals(HTTP.OK, response.statusCode());
-            Assert.assertTrue(TestUtils.responseHasContentType(response, MediaType.IMAGE_TIFF));
-            Assert.assertTrue(Arrays.equals(expectedResponse, response.body()));
+            assertEquals(HTTP.OK, response.statusCode());
+            assertTrue(TestUtils.responseHasContentType(response, MediaType.IMAGE_TIFF));
+            assertTrue(Arrays.equals(expectedResponse, response.body()));
         }
 
         @Override
         public void testNoAccessResponseAllOrNothingUnauthorized() throws IOException, InterruptedException {
             final HttpResponse<byte[]> response = sendImageRequest(ALL_OR_NOTHING_ACCESS_IMAGE, null, 2);
 
-            Assert.assertEquals(HTTP.UNAUTHORIZED, response.statusCode());
-            Assert.assertFalse(TestUtils.responseHasContentType(response, MediaType.IMAGE_TIFF));
+            assertEquals(HTTP.UNAUTHORIZED, response.statusCode());
+            assertFalse(TestUtils.responseHasContentType(response, MediaType.IMAGE_TIFF));
         }
     }
 
@@ -598,9 +601,9 @@ public class CantaloupeAuthDelegateIT {
             final HttpResponse<byte[]> response = sendImageRequest(OPEN_ACCESS_IMAGE, null, 3);
             final byte[] expectedResponse = getExpectedImage(OPEN_ACCESS_IMAGE);
 
-            Assert.assertEquals(HTTP.OK, response.statusCode());
-            Assert.assertTrue(TestUtils.responseHasContentType(response, MediaType.IMAGE_TIFF));
-            Assert.assertTrue(Arrays.equals(expectedResponse, response.body()));
+            assertEquals(HTTP.OK, response.statusCode());
+            assertTrue(TestUtils.responseHasContentType(response, MediaType.IMAGE_TIFF));
+            assertTrue(Arrays.equals(expectedResponse, response.body()));
         }
 
         @Override
@@ -631,17 +634,17 @@ public class CantaloupeAuthDelegateIT {
             final HttpResponse<byte[]> response = sendImageRequest(ALL_OR_NOTHING_ACCESS_IMAGE, cookieHeader, 3);
             final byte[] expectedResponse = getExpectedImage(ALL_OR_NOTHING_ACCESS_IMAGE);
 
-            Assert.assertEquals(HTTP.OK, response.statusCode());
-            Assert.assertTrue(TestUtils.responseHasContentType(response, MediaType.IMAGE_TIFF));
-            Assert.assertTrue(Arrays.equals(expectedResponse, response.body()));
+            assertEquals(HTTP.OK, response.statusCode());
+            assertTrue(TestUtils.responseHasContentType(response, MediaType.IMAGE_TIFF));
+            assertTrue(Arrays.equals(expectedResponse, response.body()));
         }
 
         @Override
         public void testNoAccessResponseAllOrNothingUnauthorized() throws IOException, InterruptedException {
             final HttpResponse<byte[]> response = sendImageRequest(ALL_OR_NOTHING_ACCESS_IMAGE, null, 3);
 
-            Assert.assertEquals(HTTP.UNAUTHORIZED, response.statusCode());
-            Assert.assertFalse(TestUtils.responseHasContentType(response, MediaType.IMAGE_TIFF));
+            assertEquals(HTTP.UNAUTHORIZED, response.statusCode());
+            assertFalse(TestUtils.responseHasContentType(response, MediaType.IMAGE_TIFF));
         }
     }
 }

--- a/src/test/java/edu/ucla/library/iiif/auth/delegate/CantaloupeAuthDelegateIT.java
+++ b/src/test/java/edu/ucla/library/iiif/auth/delegate/CantaloupeAuthDelegateIT.java
@@ -10,10 +10,14 @@ import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.net.http.HttpResponse.BodyHandlers;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.commons.io.FileUtils;
+
 import org.junit.Assert;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import info.freelibrary.util.HTTP;
@@ -59,6 +63,42 @@ public class CantaloupeAuthDelegateIT {
      */
     private static final String SINAI_ACCESS_TOKEN =
             "eyJ2ZXJzaW9uIjogIjAuMC4wLVNOQVBTSE9UIiwgInNpbmFpQWZmaWxpYXRlIjogdHJ1ZX0K";
+
+    /**
+     * A test initialization vector used to encrypt {@link #TEST_SINAI_AUTHENTICATED_3DAY}. This is just the value
+     * "0123456789ABCDEF" (see Ruby script below) encoded in hexadecimal.
+     */
+    private static final String TEST_INITIALIZATION_VECTOR = "30313233343536373839414243444546";
+
+    @SuppressWarnings("checkstyle:lineLengthChecker")
+    /**
+     * A test cookie generated using the following Ruby code, mocking the relevant part of the Sinai application:
+     * <p>
+     *
+     * <pre>
+     * #!/usr/bin/env ruby
+     *
+     * require "openssl"
+     *
+     * cipher = OpenSSL::Cipher::AES256.new :CBC
+     * cipher.encrypt
+     * cipher.key = "ThisPasswordIsReallyHardToGuess!"
+     * cipher.iv = "0123456789ABCDEF"
+     * puts (cipher.update("Authenticated #{Time.at(0).utc}") + cipher.final).unpack("H*")[0].upcase
+     * </pre>
+     *
+     * @see <a href=
+     *      "https://github.com/UCLALibrary/sinaimanuscripts/blob/44cbbd9bf508c32b742f1617205a679edf77603e/app/controllers/application_controller.rb#L98-L103">How
+     *      the Sinai application encodes cookies</a>
+     */
+    private static final String TEST_SINAI_AUTHENTICATED_3DAY =
+            "5AFF80488740353F8A11B99C7A493D871807521908500772B92E4F8FC919E305A607ADB714B22EF08D2C22FC08C8A6EC";
+
+    /**
+     * The Cookie header template for Sinai image requests.
+     */
+    private static final String SINAI_COOKIE_REQUEST_HEADER_TEMPLATE =
+            "sinai_authenticated_3day={}; initialization_vector={}";
 
     /**
      * The id of the non-restricted image.
@@ -149,7 +189,7 @@ public class CantaloupeAuthDelegateIT {
     private static HttpResponse<String> sendImageInfoRequest(final String aImageID, final String aToken,
             final int aImageApiVersion) throws IOException, InterruptedException {
         final String imageURL =
-                getDescriptionResourceID(System.getenv().get(TestConfig.IIIF_URL_PROPERTY), aImageApiVersion, aImageID);
+                getImageInfoURL(System.getenv().get(TestConfig.IIIF_URL_PROPERTY), aImageApiVersion, aImageID);
         final HttpRequest.Builder requestBuilder = HttpRequest.newBuilder(URI.create(imageURL + "/info.json"));
 
         if (aToken != null) {
@@ -160,19 +200,42 @@ public class CantaloupeAuthDelegateIT {
     }
 
     /**
-     * Generates the expected info.json for a given image.
+     * Sends an HTTP request for the image.
+     *
+     * @param aImageID The identifier of the image whose info we're requesting
+     * @param aCookieHeader The Cookie HTTP header to send with the request
+     * @param aImageApiVersion The IIIF Image API endpoint to use
+     * @return The HTTP response
+     * @throws IOException If there is trouble sending the HTTP request
+     * @throws InterruptedException If there is trouble sending the HTTP request
+     */
+    private static HttpResponse<byte[]> sendImageRequest(final String aImageID, final String aCookieHeader,
+            final int aImageApiVersion) throws IOException, InterruptedException {
+        final String imageURL =
+                getImageURL(System.getenv().get(TestConfig.IIIF_URL_PROPERTY), aImageApiVersion, aImageID);
+        final HttpRequest.Builder requestBuilder = HttpRequest.newBuilder(URI.create(imageURL));
+
+        if (aCookieHeader != null) {
+            requestBuilder.header("Cookie", aCookieHeader);
+        }
+
+        return HTTP_CLIENT.send(requestBuilder.build(), BodyHandlers.ofByteArray());
+    }
+
+    /**
+     * Determines the info.json that is expected in the response.
      *
      * @param aImageID The identifier of the image whose info we're requesting
      * @param aResponseTemplate The response template that we should use to render the response
      * @param aImageApiVersion The IIIF Image API endpoint to use
-     * @return The expected info.json response for the image
-     * @throws IOException If there is trouble reading the test file
+     * @return The info.json that is expected in the response
+     * @throws IOException If there is trouble reading the info.json template file
      */
-    private static String getExpectedDescriptionResource(final String aImageID, final File aResponseTemplate,
+    private static String getExpectedImageInfo(final String aImageID, final File aResponseTemplate,
             final int aImageApiVersion) throws IOException {
         final Map<String, String> envProperties = System.getenv();
         final String descriptionResourceID =
-                getDescriptionResourceID(envProperties.get(TestConfig.IIIF_URL_PROPERTY), aImageApiVersion, aImageID);
+                getImageInfoURL(envProperties.get(TestConfig.IIIF_URL_PROPERTY), aImageApiVersion, aImageID);
         final List<String> responseTemplateURLs = new ArrayList<>();
 
         responseTemplateURLs.add(descriptionResourceID);
@@ -191,16 +254,56 @@ public class CantaloupeAuthDelegateIT {
     }
 
     /**
-     * Constructs the ID of a description resource.
+     * Determines the image that is expected in the response.
+     *
+     * @param aImageID The identifier of the image that we're requesting
+     * @return The image that is expected in the response
+     * @throws IOException If there is trouble reading the image file
+     */
+    private static byte[] getExpectedImage(final String aImageID) throws IOException {
+        final File imageFile = new File("src/test/resources/images/" + aImageID);
+
+        return FileUtils.readFileToByteArray(imageFile);
+    }
+
+    /**
+     * Constructs the URL of an info.json.
      *
      * @param aBaseURL The base URL of the Cantaloupe server
      * @param aImageApiVersion The IIIF Image API version
      * @param aImageID The identifier of the image
-     * @return The ID of the description resource
+     * @return The URL of the info.json
      */
-    private static String getDescriptionResourceID(final String aBaseURL, final int aImageApiVersion,
-            final String aImageID) {
+    private static String getImageInfoURL(final String aBaseURL, final int aImageApiVersion, final String aImageID) {
         return StringUtils.format(IMAGE_URL_TEMPLATE, aBaseURL, aImageApiVersion, aImageID);
+    }
+
+    /**
+     * Constructs the URL of an image.
+     *
+     * @param aBaseURL The base URL of the Cantaloupe server
+     * @param aImageApiVersion The IIIF Image API version
+     * @param aImageID The identifier of the image
+     * @return The URL of the image
+     */
+    private static String getImageURL(final String aBaseURL, final int aImageApiVersion, final String aImageID) {
+        final String imageApiPathTemplate;
+        final String imageApiPath;
+
+        // Use TIFFs so that we can easily compare the response payload with the source image
+        switch (aImageApiVersion) {
+            case 2:
+                imageApiPathTemplate = "{}/full/full/0/default.tif";
+                break;
+            case 3:
+            default:
+                imageApiPathTemplate = "{}/full/max/0/default.tif";
+                break;
+        }
+
+        imageApiPath = StringUtils.format(imageApiPathTemplate, aImageID);
+
+        return StringUtils.format(IMAGE_URL_TEMPLATE, aBaseURL, aImageApiVersion, imageApiPath);
     }
 
     /*********
@@ -227,7 +330,7 @@ public class CantaloupeAuthDelegateIT {
          * @throws IOException If there is trouble sending the HTTP request(s) or getting the expected response response
          * @throws InterruptedException If there is trouble sending the HTTP request(s)
          */
-        public abstract void testFullResponseTieredAuthorized() throws IOException, InterruptedException;
+        public abstract void testFullAccessResponseTieredAuthorized() throws IOException, InterruptedException;
 
         /**
          * Tests that the HTTP response to an unauthorized request for a tiered access item indicates degraded access.
@@ -276,7 +379,7 @@ public class CantaloupeAuthDelegateIT {
         public final void testFullAccessResponseOpenUnauthorized() throws IOException, InterruptedException {
             final HttpResponse<String> response = sendImageInfoRequest(OPEN_ACCESS_IMAGE, null, 2);
             final String expectedResponse =
-                    getExpectedDescriptionResource(OPEN_ACCESS_IMAGE, FULL_ACCESS_RESPONSE_TEMPLATE_V2, 2);
+                    getExpectedImageInfo(OPEN_ACCESS_IMAGE, FULL_ACCESS_RESPONSE_TEMPLATE_V2, 2);
 
             Assert.assertEquals(HTTP.OK, response.statusCode());
             TestUtils.assertEquals(expectedResponse, response.body());
@@ -284,10 +387,10 @@ public class CantaloupeAuthDelegateIT {
 
         @Override
         @Test
-        public final void testFullResponseTieredAuthorized() throws IOException, InterruptedException {
+        public final void testFullAccessResponseTieredAuthorized() throws IOException, InterruptedException {
             final HttpResponse<String> response = sendImageInfoRequest(TIERED_ACCESS_IMAGE, ACCESS_TOKEN, 2);
             final String expectedResponse =
-                    getExpectedDescriptionResource(TIERED_ACCESS_IMAGE, FULL_ACCESS_RESPONSE_TEMPLATE_V2, 2);
+                    getExpectedImageInfo(TIERED_ACCESS_IMAGE, FULL_ACCESS_RESPONSE_TEMPLATE_V2, 2);
 
             Assert.assertEquals(HTTP.OK, response.statusCode());
             TestUtils.assertEquals(expectedResponse, response.body());
@@ -297,8 +400,8 @@ public class CantaloupeAuthDelegateIT {
         @Test
         public final void testDegradedAccessResponseTieredUnauthorized() throws IOException, InterruptedException {
             final HttpResponse<String> response = sendImageInfoRequest(TIERED_ACCESS_IMAGE, null, 2);
-            final String expectedResponse = getExpectedDescriptionResource(TIERED_ACCESS_IMAGE_DEGRADED_VALID,
-                    DEGRADED_ACCESS_RESPONSE_TEMPLATE_V2, 2);
+            final String expectedResponse =
+                    getExpectedImageInfo(TIERED_ACCESS_IMAGE_DEGRADED_VALID, DEGRADED_ACCESS_RESPONSE_TEMPLATE_V2, 2);
 
             Assert.assertEquals(HTTP.OK, response.statusCode());
             TestUtils.assertEquals(expectedResponse, response.body());
@@ -313,14 +416,13 @@ public class CantaloupeAuthDelegateIT {
             Assert.assertEquals(HTTP.FORBIDDEN, response.statusCode());
         }
 
-
         @Override
         @Test
         public final void testFullAccessResponseAllOrNothingAuthorized() throws IOException, InterruptedException {
             final HttpResponse<String> response =
                     sendImageInfoRequest(ALL_OR_NOTHING_ACCESS_IMAGE, SINAI_ACCESS_TOKEN, 2);
             final String expectedResponse =
-                    getExpectedDescriptionResource(ALL_OR_NOTHING_ACCESS_IMAGE, FULL_ACCESS_RESPONSE_TEMPLATE_V2, 2);
+                    getExpectedImageInfo(ALL_OR_NOTHING_ACCESS_IMAGE, FULL_ACCESS_RESPONSE_TEMPLATE_V2, 2);
 
             Assert.assertEquals(HTTP.OK, response.statusCode());
             TestUtils.assertEquals(expectedResponse, response.body());
@@ -331,7 +433,7 @@ public class CantaloupeAuthDelegateIT {
         public final void testNoAccessResponseAllOrNothingUnauthorized() throws IOException, InterruptedException {
             final HttpResponse<String> response = sendImageInfoRequest(ALL_OR_NOTHING_ACCESS_IMAGE, null, 2);
             final String expectedResponse =
-                    getExpectedDescriptionResource(ALL_OR_NOTHING_ACCESS_IMAGE, NO_ACCESS_RESPONSE_TEMPLATE_V2, 2);
+                    getExpectedImageInfo(ALL_OR_NOTHING_ACCESS_IMAGE, NO_ACCESS_RESPONSE_TEMPLATE_V2, 2);
 
             Assert.assertEquals(HTTP.UNAUTHORIZED, response.statusCode());
             TestUtils.assertEquals(expectedResponse, response.body());
@@ -348,7 +450,7 @@ public class CantaloupeAuthDelegateIT {
         public final void testFullAccessResponseOpenUnauthorized() throws IOException, InterruptedException {
             final HttpResponse<String> response = sendImageInfoRequest(OPEN_ACCESS_IMAGE, null, 3);
             final String expectedResponse =
-                    getExpectedDescriptionResource(OPEN_ACCESS_IMAGE, FULL_ACCESS_RESPONSE_TEMPLATE_V3, 3);
+                    getExpectedImageInfo(OPEN_ACCESS_IMAGE, FULL_ACCESS_RESPONSE_TEMPLATE_V3, 3);
 
             Assert.assertEquals(HTTP.OK, response.statusCode());
             TestUtils.assertEquals(expectedResponse, response.body());
@@ -356,10 +458,10 @@ public class CantaloupeAuthDelegateIT {
 
         @Override
         @Test
-        public final void testFullResponseTieredAuthorized() throws IOException, InterruptedException {
+        public final void testFullAccessResponseTieredAuthorized() throws IOException, InterruptedException {
             final HttpResponse<String> response = sendImageInfoRequest(TIERED_ACCESS_IMAGE, ACCESS_TOKEN, 3);
             final String expectedResponse =
-                    getExpectedDescriptionResource(TIERED_ACCESS_IMAGE, FULL_ACCESS_RESPONSE_TEMPLATE_V3, 3);
+                    getExpectedImageInfo(TIERED_ACCESS_IMAGE, FULL_ACCESS_RESPONSE_TEMPLATE_V3, 3);
 
             Assert.assertEquals(HTTP.OK, response.statusCode());
             TestUtils.assertEquals(expectedResponse, response.body());
@@ -369,8 +471,8 @@ public class CantaloupeAuthDelegateIT {
         @Test
         public final void testDegradedAccessResponseTieredUnauthorized() throws IOException, InterruptedException {
             final HttpResponse<String> response = sendImageInfoRequest(TIERED_ACCESS_IMAGE, null, 3);
-            final String expectedResponse = getExpectedDescriptionResource(TIERED_ACCESS_IMAGE_DEGRADED_VALID,
-                    DEGRADED_ACCESS_RESPONSE_TEMPLATE_V3, 3);
+            final String expectedResponse =
+                    getExpectedImageInfo(TIERED_ACCESS_IMAGE_DEGRADED_VALID, DEGRADED_ACCESS_RESPONSE_TEMPLATE_V3, 3);
 
             Assert.assertEquals(HTTP.OK, response.statusCode());
             TestUtils.assertEquals(expectedResponse, response.body());
@@ -391,7 +493,7 @@ public class CantaloupeAuthDelegateIT {
             final HttpResponse<String> response =
                     sendImageInfoRequest(ALL_OR_NOTHING_ACCESS_IMAGE, SINAI_ACCESS_TOKEN, 3);
             final String expectedResponse =
-                    getExpectedDescriptionResource(ALL_OR_NOTHING_ACCESS_IMAGE, FULL_ACCESS_RESPONSE_TEMPLATE_V3, 3);
+                    getExpectedImageInfo(ALL_OR_NOTHING_ACCESS_IMAGE, FULL_ACCESS_RESPONSE_TEMPLATE_V3, 3);
 
             Assert.assertEquals(HTTP.OK, response.statusCode());
             TestUtils.assertEquals(expectedResponse, response.body());
@@ -402,10 +504,124 @@ public class CantaloupeAuthDelegateIT {
         public final void testNoAccessResponseAllOrNothingUnauthorized() throws IOException, InterruptedException {
             final HttpResponse<String> response = sendImageInfoRequest(ALL_OR_NOTHING_ACCESS_IMAGE, null, 3);
             final String expectedResponse =
-                    getExpectedDescriptionResource(ALL_OR_NOTHING_ACCESS_IMAGE, NO_ACCESS_RESPONSE_TEMPLATE_V3, 3);
+                    getExpectedImageInfo(ALL_OR_NOTHING_ACCESS_IMAGE, NO_ACCESS_RESPONSE_TEMPLATE_V3, 3);
 
             Assert.assertEquals(HTTP.UNAUTHORIZED, response.statusCode());
             TestUtils.assertEquals(expectedResponse, response.body());
+        }
+    }
+
+    /**
+     * Tests for image requests via Image API 2.
+     */
+    public static class ImageRequestV2IT extends AbstractRequestIT {
+
+        @Override
+        @Test
+        public void testFullAccessResponseOpenUnauthorized() throws IOException, InterruptedException {
+            final HttpResponse<byte[]> response = sendImageRequest(OPEN_ACCESS_IMAGE, null, 2);
+            final byte[] expectedResponse = getExpectedImage(OPEN_ACCESS_IMAGE);
+
+            Assert.assertEquals(HTTP.OK, response.statusCode());
+            Assert.assertTrue(Arrays.equals(expectedResponse, response.body()));
+        }
+
+        @Override
+        @Test
+        @Ignore
+        public void testFullAccessResponseTieredAuthorized() throws IOException, InterruptedException {
+            // TODO Auto-generated method stub
+        }
+
+        @Override
+        @Test
+        @Ignore
+        public void testDegradedAccessResponseTieredUnauthorized() throws IOException, InterruptedException {
+            // TODO Auto-generated method stub
+        }
+
+        @Override
+        @Test
+        @Ignore
+        public void testErrorResponseTieredDisallowedScale() throws IOException, InterruptedException {
+            // TODO Auto-generated method stub
+        }
+
+        @Override
+        @Test
+        public void testFullAccessResponseAllOrNothingAuthorized() throws IOException, InterruptedException {
+            final String cookieHeader = StringUtils.format(SINAI_COOKIE_REQUEST_HEADER_TEMPLATE,
+                    TEST_SINAI_AUTHENTICATED_3DAY, TEST_INITIALIZATION_VECTOR);
+            final HttpResponse<byte[]> response = sendImageRequest(ALL_OR_NOTHING_ACCESS_IMAGE, cookieHeader, 2);
+            final byte[] expectedResponse = getExpectedImage(ALL_OR_NOTHING_ACCESS_IMAGE);
+
+            Assert.assertEquals(HTTP.OK, response.statusCode());
+            Assert.assertTrue(Arrays.equals(expectedResponse, response.body()));
+        }
+
+        @Override
+        @Test
+        public void testNoAccessResponseAllOrNothingUnauthorized() throws IOException, InterruptedException {
+            final HttpResponse<byte[]> response = sendImageRequest(ALL_OR_NOTHING_ACCESS_IMAGE, null, 2);
+
+            Assert.assertEquals(HTTP.UNAUTHORIZED, response.statusCode());
+        }
+    }
+
+    /**
+     * Tests for image requests via Image API 3.
+     */
+    public static class ImageRequestV3IT extends AbstractRequestIT {
+
+        @Override
+        @Test
+        public void testFullAccessResponseOpenUnauthorized() throws IOException, InterruptedException {
+            final HttpResponse<byte[]> response = sendImageRequest(OPEN_ACCESS_IMAGE, null, 3);
+            final byte[] expectedResponse = getExpectedImage(OPEN_ACCESS_IMAGE);
+
+            Assert.assertEquals(HTTP.OK, response.statusCode());
+            Assert.assertTrue(Arrays.equals(expectedResponse, response.body()));
+        }
+
+        @Override
+        @Test
+        @Ignore
+        public void testFullAccessResponseTieredAuthorized() throws IOException, InterruptedException {
+            // TODO Auto-generated method stub
+        }
+
+        @Override
+        @Test
+        @Ignore
+        public void testDegradedAccessResponseTieredUnauthorized() throws IOException, InterruptedException {
+            // TODO Auto-generated method stub
+        }
+
+        @Override
+        @Test
+        @Ignore
+        public void testErrorResponseTieredDisallowedScale() throws IOException, InterruptedException {
+            // TODO Auto-generated method stub
+        }
+
+        @Override
+        @Test
+        public void testFullAccessResponseAllOrNothingAuthorized() throws IOException, InterruptedException {
+            final String cookieHeader = StringUtils.format(SINAI_COOKIE_REQUEST_HEADER_TEMPLATE,
+                    TEST_SINAI_AUTHENTICATED_3DAY, TEST_INITIALIZATION_VECTOR);
+            final HttpResponse<byte[]> response = sendImageRequest(ALL_OR_NOTHING_ACCESS_IMAGE, cookieHeader, 3);
+            final byte[] expectedResponse = getExpectedImage(ALL_OR_NOTHING_ACCESS_IMAGE);
+
+            Assert.assertEquals(HTTP.OK, response.statusCode());
+            Assert.assertTrue(Arrays.equals(expectedResponse, response.body()));
+        }
+
+        @Override
+        @Test
+        public void testNoAccessResponseAllOrNothingUnauthorized() throws IOException, InterruptedException {
+            final HttpResponse<byte[]> response = sendImageRequest(ALL_OR_NOTHING_ACCESS_IMAGE, null, 3);
+
+            Assert.assertEquals(HTTP.UNAUTHORIZED, response.statusCode());
         }
     }
 }

--- a/src/test/java/edu/ucla/library/iiif/auth/delegate/CantaloupeAuthDelegateIT.java
+++ b/src/test/java/edu/ucla/library/iiif/auth/delegate/CantaloupeAuthDelegateIT.java
@@ -23,6 +23,8 @@ import org.junit.Test;
 import info.freelibrary.util.HTTP;
 import info.freelibrary.util.StringUtils;
 
+import info.freelibrary.iiif.presentation.v3.MediaType;
+
 import edu.ucla.library.iiif.auth.delegate.hauth.HauthToken;
 
 /**
@@ -387,6 +389,8 @@ public class CantaloupeAuthDelegateIT {
                     getExpectedImageInfo(OPEN_ACCESS_IMAGE, FULL_ACCESS_RESPONSE_TEMPLATE_V2, 2);
 
             Assert.assertEquals(HTTP.OK, response.statusCode());
+            Assert.assertTrue(TestUtils.responseHasContentType(response, MediaType.APPLICATION_JSON,
+                    MediaType.APPLICATION_LD_PLUS_JSON));
             TestUtils.assertEquals(expectedResponse, response.body());
         }
 
@@ -397,6 +401,8 @@ public class CantaloupeAuthDelegateIT {
                     getExpectedImageInfo(TIERED_ACCESS_IMAGE, FULL_ACCESS_RESPONSE_TEMPLATE_V2, 2);
 
             Assert.assertEquals(HTTP.OK, response.statusCode());
+            Assert.assertTrue(TestUtils.responseHasContentType(response, MediaType.APPLICATION_JSON,
+                    MediaType.APPLICATION_LD_PLUS_JSON));
             TestUtils.assertEquals(expectedResponse, response.body());
         }
 
@@ -407,6 +413,8 @@ public class CantaloupeAuthDelegateIT {
                     getExpectedImageInfo(TIERED_ACCESS_IMAGE_DEGRADED_VALID, DEGRADED_ACCESS_RESPONSE_TEMPLATE_V2, 2);
 
             Assert.assertEquals(HTTP.OK, response.statusCode());
+            Assert.assertTrue(TestUtils.responseHasContentType(response, MediaType.APPLICATION_JSON,
+                    MediaType.APPLICATION_LD_PLUS_JSON));
             TestUtils.assertEquals(expectedResponse, response.body());
         }
 
@@ -416,6 +424,8 @@ public class CantaloupeAuthDelegateIT {
                     sendImageInfoRequest(TIERED_ACCESS_IMAGE_DEGRADED_UNAVAILABLE, null, 2);
 
             Assert.assertEquals(HTTP.FORBIDDEN, response.statusCode());
+            Assert.assertFalse(TestUtils.responseHasContentType(response, MediaType.APPLICATION_JSON,
+                    MediaType.APPLICATION_LD_PLUS_JSON));
         }
 
         @Override
@@ -426,6 +436,8 @@ public class CantaloupeAuthDelegateIT {
                     getExpectedImageInfo(ALL_OR_NOTHING_ACCESS_IMAGE, FULL_ACCESS_RESPONSE_TEMPLATE_V2, 2);
 
             Assert.assertEquals(HTTP.OK, response.statusCode());
+            Assert.assertTrue(TestUtils.responseHasContentType(response, MediaType.APPLICATION_JSON,
+                    MediaType.APPLICATION_LD_PLUS_JSON));
             TestUtils.assertEquals(expectedResponse, response.body());
         }
 
@@ -436,6 +448,8 @@ public class CantaloupeAuthDelegateIT {
                     getExpectedImageInfo(ALL_OR_NOTHING_ACCESS_IMAGE, NO_ACCESS_RESPONSE_TEMPLATE_V2, 2);
 
             Assert.assertEquals(HTTP.UNAUTHORIZED, response.statusCode());
+            Assert.assertTrue(TestUtils.responseHasContentType(response, MediaType.APPLICATION_JSON,
+                    MediaType.APPLICATION_LD_PLUS_JSON));
             TestUtils.assertEquals(expectedResponse, response.body());
         }
     }
@@ -452,6 +466,8 @@ public class CantaloupeAuthDelegateIT {
                     getExpectedImageInfo(OPEN_ACCESS_IMAGE, FULL_ACCESS_RESPONSE_TEMPLATE_V3, 3);
 
             Assert.assertEquals(HTTP.OK, response.statusCode());
+            Assert.assertTrue(TestUtils.responseHasContentType(response, MediaType.APPLICATION_JSON,
+                    MediaType.APPLICATION_LD_PLUS_JSON));
             TestUtils.assertEquals(expectedResponse, response.body());
         }
 
@@ -462,6 +478,8 @@ public class CantaloupeAuthDelegateIT {
                     getExpectedImageInfo(TIERED_ACCESS_IMAGE, FULL_ACCESS_RESPONSE_TEMPLATE_V3, 3);
 
             Assert.assertEquals(HTTP.OK, response.statusCode());
+            Assert.assertTrue(TestUtils.responseHasContentType(response, MediaType.APPLICATION_JSON,
+                    MediaType.APPLICATION_LD_PLUS_JSON));
             TestUtils.assertEquals(expectedResponse, response.body());
         }
 
@@ -472,6 +490,8 @@ public class CantaloupeAuthDelegateIT {
                     getExpectedImageInfo(TIERED_ACCESS_IMAGE_DEGRADED_VALID, DEGRADED_ACCESS_RESPONSE_TEMPLATE_V3, 3);
 
             Assert.assertEquals(HTTP.OK, response.statusCode());
+            Assert.assertTrue(TestUtils.responseHasContentType(response, MediaType.APPLICATION_JSON,
+                    MediaType.APPLICATION_LD_PLUS_JSON));
             TestUtils.assertEquals(expectedResponse, response.body());
         }
 
@@ -481,6 +501,8 @@ public class CantaloupeAuthDelegateIT {
                     sendImageInfoRequest(TIERED_ACCESS_IMAGE_DEGRADED_UNAVAILABLE, null, 3);
 
             Assert.assertEquals(HTTP.FORBIDDEN, response.statusCode());
+            Assert.assertFalse(TestUtils.responseHasContentType(response, MediaType.APPLICATION_JSON,
+                    MediaType.APPLICATION_LD_PLUS_JSON));
         }
 
         @Override
@@ -491,6 +513,8 @@ public class CantaloupeAuthDelegateIT {
                     getExpectedImageInfo(ALL_OR_NOTHING_ACCESS_IMAGE, FULL_ACCESS_RESPONSE_TEMPLATE_V3, 3);
 
             Assert.assertEquals(HTTP.OK, response.statusCode());
+            Assert.assertTrue(TestUtils.responseHasContentType(response, MediaType.APPLICATION_JSON,
+                    MediaType.APPLICATION_LD_PLUS_JSON));
             TestUtils.assertEquals(expectedResponse, response.body());
         }
 
@@ -501,6 +525,8 @@ public class CantaloupeAuthDelegateIT {
                     getExpectedImageInfo(ALL_OR_NOTHING_ACCESS_IMAGE, NO_ACCESS_RESPONSE_TEMPLATE_V3, 3);
 
             Assert.assertEquals(HTTP.UNAUTHORIZED, response.statusCode());
+            Assert.assertTrue(TestUtils.responseHasContentType(response, MediaType.APPLICATION_JSON,
+                    MediaType.APPLICATION_LD_PLUS_JSON));
             TestUtils.assertEquals(expectedResponse, response.body());
         }
     }
@@ -516,6 +542,7 @@ public class CantaloupeAuthDelegateIT {
             final byte[] expectedResponse = getExpectedImage(OPEN_ACCESS_IMAGE);
 
             Assert.assertEquals(HTTP.OK, response.statusCode());
+            Assert.assertTrue(TestUtils.responseHasContentType(response, MediaType.IMAGE_TIFF));
             Assert.assertTrue(Arrays.equals(expectedResponse, response.body()));
         }
 
@@ -548,6 +575,7 @@ public class CantaloupeAuthDelegateIT {
             final byte[] expectedResponse = getExpectedImage(ALL_OR_NOTHING_ACCESS_IMAGE);
 
             Assert.assertEquals(HTTP.OK, response.statusCode());
+            Assert.assertTrue(TestUtils.responseHasContentType(response, MediaType.IMAGE_TIFF));
             Assert.assertTrue(Arrays.equals(expectedResponse, response.body()));
         }
 
@@ -556,6 +584,7 @@ public class CantaloupeAuthDelegateIT {
             final HttpResponse<byte[]> response = sendImageRequest(ALL_OR_NOTHING_ACCESS_IMAGE, null, 2);
 
             Assert.assertEquals(HTTP.UNAUTHORIZED, response.statusCode());
+            Assert.assertFalse(TestUtils.responseHasContentType(response, MediaType.IMAGE_TIFF));
         }
     }
 
@@ -570,6 +599,7 @@ public class CantaloupeAuthDelegateIT {
             final byte[] expectedResponse = getExpectedImage(OPEN_ACCESS_IMAGE);
 
             Assert.assertEquals(HTTP.OK, response.statusCode());
+            Assert.assertTrue(TestUtils.responseHasContentType(response, MediaType.IMAGE_TIFF));
             Assert.assertTrue(Arrays.equals(expectedResponse, response.body()));
         }
 
@@ -602,6 +632,7 @@ public class CantaloupeAuthDelegateIT {
             final byte[] expectedResponse = getExpectedImage(ALL_OR_NOTHING_ACCESS_IMAGE);
 
             Assert.assertEquals(HTTP.OK, response.statusCode());
+            Assert.assertTrue(TestUtils.responseHasContentType(response, MediaType.IMAGE_TIFF));
             Assert.assertTrue(Arrays.equals(expectedResponse, response.body()));
         }
 
@@ -610,6 +641,7 @@ public class CantaloupeAuthDelegateIT {
             final HttpResponse<byte[]> response = sendImageRequest(ALL_OR_NOTHING_ACCESS_IMAGE, null, 3);
 
             Assert.assertEquals(HTTP.UNAUTHORIZED, response.statusCode());
+            Assert.assertFalse(TestUtils.responseHasContentType(response, MediaType.IMAGE_TIFF));
         }
     }
 }

--- a/src/test/java/edu/ucla/library/iiif/auth/delegate/CantaloupeAuthDelegateIT.java
+++ b/src/test/java/edu/ucla/library/iiif/auth/delegate/CantaloupeAuthDelegateIT.java
@@ -322,6 +322,7 @@ public class CantaloupeAuthDelegateIT {
          * @throws IOException If there is trouble sending the HTTP request(s) or getting the expected response
          * @throws InterruptedException If there is trouble sending the HTTP request(s)
          */
+        @Test
         public abstract void testFullAccessResponseOpenUnauthorized() throws IOException, InterruptedException;
 
         /**
@@ -330,6 +331,7 @@ public class CantaloupeAuthDelegateIT {
          * @throws IOException If there is trouble sending the HTTP request(s) or getting the expected response response
          * @throws InterruptedException If there is trouble sending the HTTP request(s)
          */
+        @Test
         public abstract void testFullAccessResponseTieredAuthorized() throws IOException, InterruptedException;
 
         /**
@@ -338,6 +340,7 @@ public class CantaloupeAuthDelegateIT {
          * @throws IOException If there is trouble sending the HTTP request(s) or getting the expected response response
          * @throws InterruptedException If there is trouble sending the HTTP request(s)
          */
+        @Test
         public abstract void testDegradedAccessResponseTieredUnauthorized() throws IOException, InterruptedException;
 
         /**
@@ -348,6 +351,7 @@ public class CantaloupeAuthDelegateIT {
          *         response
          * @throws InterruptedException If there is trouble sending the HTTP request(s)
          */
+        @Test
         public abstract void testErrorResponseTieredDisallowedScale() throws IOException, InterruptedException;
 
         /**
@@ -357,6 +361,7 @@ public class CantaloupeAuthDelegateIT {
          * @throws IOException If there is trouble sending the HTTP request(s) or getting the expected response response
          * @throws InterruptedException If there is trouble sending the HTTP request(s)
          */
+        @Test
         public abstract void testFullAccessResponseAllOrNothingAuthorized() throws IOException, InterruptedException;
 
         /**
@@ -366,6 +371,7 @@ public class CantaloupeAuthDelegateIT {
          * @throws IOException If there is trouble sending the HTTP request(s) or getting the expected response response
          * @throws InterruptedException If there is trouble sending the HTTP request(s)
          */
+        @Test
         public abstract void testNoAccessResponseAllOrNothingUnauthorized() throws IOException, InterruptedException;
     }
 
@@ -375,7 +381,6 @@ public class CantaloupeAuthDelegateIT {
     public static class InformationRequestV2IT extends AbstractRequestIT {
 
         @Override
-        @Test
         public final void testFullAccessResponseOpenUnauthorized() throws IOException, InterruptedException {
             final HttpResponse<String> response = sendImageInfoRequest(OPEN_ACCESS_IMAGE, null, 2);
             final String expectedResponse =
@@ -386,7 +391,6 @@ public class CantaloupeAuthDelegateIT {
         }
 
         @Override
-        @Test
         public final void testFullAccessResponseTieredAuthorized() throws IOException, InterruptedException {
             final HttpResponse<String> response = sendImageInfoRequest(TIERED_ACCESS_IMAGE, ACCESS_TOKEN, 2);
             final String expectedResponse =
@@ -397,7 +401,6 @@ public class CantaloupeAuthDelegateIT {
         }
 
         @Override
-        @Test
         public final void testDegradedAccessResponseTieredUnauthorized() throws IOException, InterruptedException {
             final HttpResponse<String> response = sendImageInfoRequest(TIERED_ACCESS_IMAGE, null, 2);
             final String expectedResponse =
@@ -408,7 +411,6 @@ public class CantaloupeAuthDelegateIT {
         }
 
         @Override
-        @Test
         public final void testErrorResponseTieredDisallowedScale() throws IOException, InterruptedException {
             final HttpResponse<String> response =
                     sendImageInfoRequest(TIERED_ACCESS_IMAGE_DEGRADED_UNAVAILABLE, null, 2);
@@ -417,7 +419,6 @@ public class CantaloupeAuthDelegateIT {
         }
 
         @Override
-        @Test
         public final void testFullAccessResponseAllOrNothingAuthorized() throws IOException, InterruptedException {
             final HttpResponse<String> response =
                     sendImageInfoRequest(ALL_OR_NOTHING_ACCESS_IMAGE, SINAI_ACCESS_TOKEN, 2);
@@ -429,7 +430,6 @@ public class CantaloupeAuthDelegateIT {
         }
 
         @Override
-        @Test
         public final void testNoAccessResponseAllOrNothingUnauthorized() throws IOException, InterruptedException {
             final HttpResponse<String> response = sendImageInfoRequest(ALL_OR_NOTHING_ACCESS_IMAGE, null, 2);
             final String expectedResponse =
@@ -446,7 +446,6 @@ public class CantaloupeAuthDelegateIT {
     public static class InformationRequestV3IT extends AbstractRequestIT {
 
         @Override
-        @Test
         public final void testFullAccessResponseOpenUnauthorized() throws IOException, InterruptedException {
             final HttpResponse<String> response = sendImageInfoRequest(OPEN_ACCESS_IMAGE, null, 3);
             final String expectedResponse =
@@ -457,7 +456,6 @@ public class CantaloupeAuthDelegateIT {
         }
 
         @Override
-        @Test
         public final void testFullAccessResponseTieredAuthorized() throws IOException, InterruptedException {
             final HttpResponse<String> response = sendImageInfoRequest(TIERED_ACCESS_IMAGE, ACCESS_TOKEN, 3);
             final String expectedResponse =
@@ -468,7 +466,6 @@ public class CantaloupeAuthDelegateIT {
         }
 
         @Override
-        @Test
         public final void testDegradedAccessResponseTieredUnauthorized() throws IOException, InterruptedException {
             final HttpResponse<String> response = sendImageInfoRequest(TIERED_ACCESS_IMAGE, null, 3);
             final String expectedResponse =
@@ -479,7 +476,6 @@ public class CantaloupeAuthDelegateIT {
         }
 
         @Override
-        @Test
         public final void testErrorResponseTieredDisallowedScale() throws IOException, InterruptedException {
             final HttpResponse<String> response =
                     sendImageInfoRequest(TIERED_ACCESS_IMAGE_DEGRADED_UNAVAILABLE, null, 3);
@@ -488,7 +484,6 @@ public class CantaloupeAuthDelegateIT {
         }
 
         @Override
-        @Test
         public final void testFullAccessResponseAllOrNothingAuthorized() throws IOException, InterruptedException {
             final HttpResponse<String> response =
                     sendImageInfoRequest(ALL_OR_NOTHING_ACCESS_IMAGE, SINAI_ACCESS_TOKEN, 3);
@@ -500,7 +495,6 @@ public class CantaloupeAuthDelegateIT {
         }
 
         @Override
-        @Test
         public final void testNoAccessResponseAllOrNothingUnauthorized() throws IOException, InterruptedException {
             final HttpResponse<String> response = sendImageInfoRequest(ALL_OR_NOTHING_ACCESS_IMAGE, null, 3);
             final String expectedResponse =
@@ -517,7 +511,6 @@ public class CantaloupeAuthDelegateIT {
     public static class ImageRequestV2IT extends AbstractRequestIT {
 
         @Override
-        @Test
         public void testFullAccessResponseOpenUnauthorized() throws IOException, InterruptedException {
             final HttpResponse<byte[]> response = sendImageRequest(OPEN_ACCESS_IMAGE, null, 2);
             final byte[] expectedResponse = getExpectedImage(OPEN_ACCESS_IMAGE);
@@ -548,7 +541,6 @@ public class CantaloupeAuthDelegateIT {
         }
 
         @Override
-        @Test
         public void testFullAccessResponseAllOrNothingAuthorized() throws IOException, InterruptedException {
             final String cookieHeader = StringUtils.format(SINAI_COOKIE_REQUEST_HEADER_TEMPLATE,
                     TEST_SINAI_AUTHENTICATED_3DAY, TEST_INITIALIZATION_VECTOR);
@@ -560,7 +552,6 @@ public class CantaloupeAuthDelegateIT {
         }
 
         @Override
-        @Test
         public void testNoAccessResponseAllOrNothingUnauthorized() throws IOException, InterruptedException {
             final HttpResponse<byte[]> response = sendImageRequest(ALL_OR_NOTHING_ACCESS_IMAGE, null, 2);
 
@@ -574,7 +565,6 @@ public class CantaloupeAuthDelegateIT {
     public static class ImageRequestV3IT extends AbstractRequestIT {
 
         @Override
-        @Test
         public void testFullAccessResponseOpenUnauthorized() throws IOException, InterruptedException {
             final HttpResponse<byte[]> response = sendImageRequest(OPEN_ACCESS_IMAGE, null, 3);
             final byte[] expectedResponse = getExpectedImage(OPEN_ACCESS_IMAGE);
@@ -605,7 +595,6 @@ public class CantaloupeAuthDelegateIT {
         }
 
         @Override
-        @Test
         public void testFullAccessResponseAllOrNothingAuthorized() throws IOException, InterruptedException {
             final String cookieHeader = StringUtils.format(SINAI_COOKIE_REQUEST_HEADER_TEMPLATE,
                     TEST_SINAI_AUTHENTICATED_3DAY, TEST_INITIALIZATION_VECTOR);
@@ -617,7 +606,6 @@ public class CantaloupeAuthDelegateIT {
         }
 
         @Override
-        @Test
         public void testNoAccessResponseAllOrNothingUnauthorized() throws IOException, InterruptedException {
             final HttpResponse<byte[]> response = sendImageRequest(ALL_OR_NOTHING_ACCESS_IMAGE, null, 3);
 

--- a/src/test/java/edu/ucla/library/iiif/auth/delegate/CantaloupeAuthDelegateIT.java
+++ b/src/test/java/edu/ucla/library/iiif/auth/delegate/CantaloupeAuthDelegateIT.java
@@ -132,210 +132,6 @@ public class CantaloupeAuthDelegateIT {
     private static final HttpClient HTTP_CLIENT =
             HttpClient.newBuilder().followRedirects(Redirect.NORMAL).version(HttpClient.Version.HTTP_1_1).build();
 
-    /******
-     * v2 *
-     ******/
-
-    /**
-     * Tests that the HTTP response to a request for an open access info.json, via Image API 2, indicates full access.
-     *
-     * @throws IOException If there is trouble sending the HTTP request(s) or getting the expected info.json response
-     * @throws InterruptedException If there is trouble sending the HTTP request(s)
-     */
-    @Test
-    public final void testFullAccessResponseOpenNoTokenV2() throws IOException, InterruptedException {
-        final HttpResponse<String> response = sendImageInfoRequest(OPEN_ACCESS_IMAGE, null, 2);
-        final String expectedResponse =
-                getExpectedDescriptionResource(OPEN_ACCESS_IMAGE, FULL_ACCESS_RESPONSE_TEMPLATE_V2, 2);
-
-        Assert.assertEquals(HTTP.OK, response.statusCode());
-        TestUtils.assertEquals(expectedResponse, response.body());
-    }
-
-    /**
-     * Tests that the HTTP response to a properly authorized request for a tiered access info.json, via Image API 2,
-     * indicates full access.
-     *
-     * @throws IOException If there is trouble sending the HTTP request(s) or getting the expected info.json response
-     * @throws InterruptedException If there is trouble sending the HTTP request(s)
-     */
-    @Test
-    public final void testFullResponseTieredWithTokenV2() throws IOException, InterruptedException {
-        final HttpResponse<String> response = sendImageInfoRequest(TIERED_ACCESS_IMAGE, ACCESS_TOKEN, 2);
-        final String expectedResponse =
-                getExpectedDescriptionResource(TIERED_ACCESS_IMAGE, FULL_ACCESS_RESPONSE_TEMPLATE_V2, 2);
-
-        Assert.assertEquals(HTTP.OK, response.statusCode());
-        TestUtils.assertEquals(expectedResponse, response.body());
-    }
-
-    /**
-     * Tests that the HTTP response to an unauthorized request for a tiered access info.json, via Image API 2, indicates
-     * degraded access.
-     *
-     * @throws IOException If there is trouble sending the HTTP request(s) or getting the expected info.json response
-     * @throws InterruptedException If there is trouble sending the HTTP request(s)
-     */
-    @Test
-    public final void testDegradedAccessResponseTieredNoTokenV2() throws IOException, InterruptedException {
-        final HttpResponse<String> response = sendImageInfoRequest(TIERED_ACCESS_IMAGE, null, 2);
-        final String expectedResponse = getExpectedDescriptionResource(TIERED_ACCESS_IMAGE_DEGRADED_VALID,
-                DEGRADED_ACCESS_RESPONSE_TEMPLATE_V2, 2);
-
-        Assert.assertEquals(HTTP.OK, response.statusCode());
-        TestUtils.assertEquals(expectedResponse, response.body());
-    }
-
-    /**
-     * Tests that the HTTP response to a request for a tiered access info.json, via Image API 2 and at a disallowed
-     * scale, indicates no access.
-     *
-     * @throws IOException If there is trouble sending the HTTP request(s) or getting the expected info.json response
-     * @throws InterruptedException If there is trouble sending the HTTP request(s)
-     */
-    @Test
-    public final void testErrorResponseTieredDisallowedScaleV2() throws IOException, InterruptedException {
-        final HttpResponse<String> response = sendImageInfoRequest(TIERED_ACCESS_IMAGE_DEGRADED_UNAVAILABLE, null, 2);
-
-        Assert.assertEquals(HTTP.FORBIDDEN, response.statusCode());
-    }
-
-    /**
-     * Tests that the HTTP response to a properly authorized request for an all-or-nothing access info.json, via Image
-     * API 2, indicates full access.
-     *
-     * @throws IOException If there is trouble sending the HTTP request(s) or getting the expected info.json response
-     * @throws InterruptedException If there is trouble sending the HTTP request(s)
-     */
-    @Test
-    public final void testFullAccessResponseAllOrNothingWithTokenV2() throws IOException, InterruptedException {
-        final HttpResponse<String> response = sendImageInfoRequest(ALL_OR_NOTHING_ACCESS_IMAGE, SINAI_ACCESS_TOKEN, 2);
-        final String expectedResponse =
-                getExpectedDescriptionResource(ALL_OR_NOTHING_ACCESS_IMAGE, FULL_ACCESS_RESPONSE_TEMPLATE_V2, 2);
-
-        Assert.assertEquals(HTTP.OK, response.statusCode());
-        TestUtils.assertEquals(expectedResponse, response.body());
-    }
-
-    /**
-     * Tests that the HTTP response to an unauthorized request for an all-or-nothing access info.json, via Image API 2,
-     * indicates no access.
-     *
-     * @throws IOException If there is trouble sending the HTTP request(s) or getting the expected info.json response
-     * @throws InterruptedException If there is trouble sending the HTTP request(s)
-     */
-    @Test
-    public final void testNoAccessResponseAllOrNothingNoTokenV2() throws IOException, InterruptedException {
-        final HttpResponse<String> response = sendImageInfoRequest(ALL_OR_NOTHING_ACCESS_IMAGE, null, 2);
-        final String expectedResponse =
-                getExpectedDescriptionResource(ALL_OR_NOTHING_ACCESS_IMAGE, NO_ACCESS_RESPONSE_TEMPLATE_V2, 2);
-
-        Assert.assertEquals(HTTP.UNAUTHORIZED, response.statusCode());
-        TestUtils.assertEquals(expectedResponse, response.body());
-    }
-
-    /******
-     * v3 *
-     ******/
-
-    /**
-     * Tests that the HTTP response to a request for an open access info.json, via Image API 3, indicates full access.
-     *
-     * @throws IOException If there is trouble sending the HTTP request(s) or getting the expected info.json response
-     * @throws InterruptedException If there is trouble sending the HTTP request(s)
-     */
-    @Test
-    public final void testFullAccessResponseOpenNoTokenV3() throws IOException, InterruptedException {
-        final HttpResponse<String> response = sendImageInfoRequest(OPEN_ACCESS_IMAGE, null, 3);
-        final String expectedResponse =
-                getExpectedDescriptionResource(OPEN_ACCESS_IMAGE, FULL_ACCESS_RESPONSE_TEMPLATE_V3, 3);
-
-        Assert.assertEquals(HTTP.OK, response.statusCode());
-        TestUtils.assertEquals(expectedResponse, response.body());
-    }
-
-    /**
-     * Tests that the HTTP response to a properly authorized request for a tiered access info.json, via Image API 3,
-     * indicates full access.
-     *
-     * @throws IOException If there is trouble sending the HTTP request(s) or getting the expected info.json response
-     * @throws InterruptedException If there is trouble sending the HTTP request(s)
-     */
-    @Test
-    public final void testFullResponseTieredWithTokenV3() throws IOException, InterruptedException {
-        final HttpResponse<String> response = sendImageInfoRequest(TIERED_ACCESS_IMAGE, ACCESS_TOKEN, 3);
-        final String expectedResponse =
-                getExpectedDescriptionResource(TIERED_ACCESS_IMAGE, FULL_ACCESS_RESPONSE_TEMPLATE_V3, 3);
-
-        Assert.assertEquals(HTTP.OK, response.statusCode());
-        TestUtils.assertEquals(expectedResponse, response.body());
-    }
-
-    /**
-     * Tests that the HTTP response to an unauthorized request for a tiered access info.json, via Image API 3, indicates
-     * degraded access.
-     *
-     * @throws IOException If there is trouble sending the HTTP request(s) or getting the expected info.json response
-     * @throws InterruptedException If there is trouble sending the HTTP request(s)
-     */
-    @Test
-    public final void testDegradedAccessResponseTieredNoTokenV3() throws IOException, InterruptedException {
-        final HttpResponse<String> response = sendImageInfoRequest(TIERED_ACCESS_IMAGE, null, 3);
-        final String expectedResponse = getExpectedDescriptionResource(TIERED_ACCESS_IMAGE_DEGRADED_VALID,
-                DEGRADED_ACCESS_RESPONSE_TEMPLATE_V3, 3);
-
-        Assert.assertEquals(HTTP.OK, response.statusCode());
-        TestUtils.assertEquals(expectedResponse, response.body());
-    }
-
-    /**
-     * Tests that the HTTP response to a request for a tiered access info.json, via Image API 3 and at a disallowed
-     * scale, indicates no access.
-     *
-     * @throws IOException If there is trouble sending the HTTP request(s) or getting the expected info.json response
-     * @throws InterruptedException If there is trouble sending the HTTP request(s)
-     */
-    @Test
-    public final void testErrorResponseTieredDisallowedScaleV3() throws IOException, InterruptedException {
-        final HttpResponse<String> response = sendImageInfoRequest(TIERED_ACCESS_IMAGE_DEGRADED_UNAVAILABLE, null, 3);
-
-        Assert.assertEquals(HTTP.FORBIDDEN, response.statusCode());
-    }
-
-    /**
-     * Tests that the HTTP response to a properly authorized request for an all-or-nothing access info.json, via Image
-     * API 3, indicates full access.
-     *
-     * @throws IOException If there is trouble sending the HTTP request(s) or getting the expected info.json response
-     * @throws InterruptedException If there is trouble sending the HTTP request(s)
-     */
-    @Test
-    public final void testFullAccessResponseAllOrNothingWithTokenV3() throws IOException, InterruptedException {
-        final HttpResponse<String> response = sendImageInfoRequest(ALL_OR_NOTHING_ACCESS_IMAGE, SINAI_ACCESS_TOKEN, 3);
-        final String expectedResponse =
-                getExpectedDescriptionResource(ALL_OR_NOTHING_ACCESS_IMAGE, FULL_ACCESS_RESPONSE_TEMPLATE_V3, 3);
-
-        Assert.assertEquals(HTTP.OK, response.statusCode());
-        TestUtils.assertEquals(expectedResponse, response.body());
-    }
-
-    /**
-     * Tests that the HTTP response to an unauthorized request for an all-or-nothing access info.json, via Image API 3,
-     * indicates no access.
-     *
-     * @throws IOException If there is trouble sending the HTTP request(s) or getting the expected info.json response
-     * @throws InterruptedException If there is trouble sending the HTTP request(s)
-     */
-    @Test
-    public final void testNoAccessResponseAllOrNothingNoTokenV3() throws IOException, InterruptedException {
-        final HttpResponse<String> response = sendImageInfoRequest(ALL_OR_NOTHING_ACCESS_IMAGE, null, 3);
-        final String expectedResponse =
-                getExpectedDescriptionResource(ALL_OR_NOTHING_ACCESS_IMAGE, NO_ACCESS_RESPONSE_TEMPLATE_V3, 3);
-
-        Assert.assertEquals(HTTP.UNAUTHORIZED, response.statusCode());
-        TestUtils.assertEquals(expectedResponse, response.body());
-    }
-
     /******************
      * Helper methods *
      ******************/
@@ -373,8 +169,7 @@ public class CantaloupeAuthDelegateIT {
      * @throws IOException If there is trouble reading the test file
      */
     private static String getExpectedDescriptionResource(final String aImageID, final File aResponseTemplate,
-            final int aImageApiVersion)
-                    throws IOException {
+            final int aImageApiVersion) throws IOException {
         final Map<String, String> envProperties = System.getenv();
         final String descriptionResourceID =
                 getDescriptionResourceID(envProperties.get(TestConfig.IIIF_URL_PROPERTY), aImageApiVersion, aImageID);
@@ -408,4 +203,209 @@ public class CantaloupeAuthDelegateIT {
         return StringUtils.format(IMAGE_URL_TEMPLATE, aBaseURL, aImageApiVersion, aImageID);
     }
 
+    /*********
+     * Tests *
+     *********/
+
+    /**
+     * An abstract base class for testing the responses to requests for both description resources (info.json) and
+     * content resources (images).
+     */
+    private abstract static class AbstractRequestIT {
+
+        /**
+         * Tests that the HTTP response to a request for an open access item indicates full access.
+         *
+         * @throws IOException If there is trouble sending the HTTP request(s) or getting the expected response
+         * @throws InterruptedException If there is trouble sending the HTTP request(s)
+         */
+        public abstract void testFullAccessResponseOpenUnauthorized() throws IOException, InterruptedException;
+
+        /**
+         * Tests that the HTTP response to a properly authorized request for a tiered access item indicates full access.
+         *
+         * @throws IOException If there is trouble sending the HTTP request(s) or getting the expected response response
+         * @throws InterruptedException If there is trouble sending the HTTP request(s)
+         */
+        public abstract void testFullResponseTieredAuthorized() throws IOException, InterruptedException;
+
+        /**
+         * Tests that the HTTP response to an unauthorized request for a tiered access item indicates degraded access.
+         *
+         * @throws IOException If there is trouble sending the HTTP request(s) or getting the expected response response
+         * @throws InterruptedException If there is trouble sending the HTTP request(s)
+         */
+        public abstract void testDegradedAccessResponseTieredUnauthorized() throws IOException, InterruptedException;
+
+        /**
+         * Tests that the HTTP response to a request for a tiered access item, at a disallowed scale, indicates no
+         * access.
+         *
+         * @throws IOException If there is trouble sending the HTTP request(s) or getting the expected info.json
+         *         response
+         * @throws InterruptedException If there is trouble sending the HTTP request(s)
+         */
+        public abstract void testErrorResponseTieredDisallowedScale() throws IOException, InterruptedException;
+
+        /**
+         * Tests that the HTTP response to a properly authorized request for an all-or-nothing access item indicates
+         * full access.
+         *
+         * @throws IOException If there is trouble sending the HTTP request(s) or getting the expected response response
+         * @throws InterruptedException If there is trouble sending the HTTP request(s)
+         */
+        public abstract void testFullAccessResponseAllOrNothingAuthorized() throws IOException, InterruptedException;
+
+        /**
+         * Tests that the HTTP response to an unauthorized request for an all-or-nothing access item indicates no
+         * access.
+         *
+         * @throws IOException If there is trouble sending the HTTP request(s) or getting the expected response response
+         * @throws InterruptedException If there is trouble sending the HTTP request(s)
+         */
+        public abstract void testNoAccessResponseAllOrNothingUnauthorized() throws IOException, InterruptedException;
+    }
+
+    /**
+     * Tests for info.json requests via Image API 2.
+     */
+    public static class InformationRequestV2IT extends AbstractRequestIT {
+
+        @Override
+        @Test
+        public final void testFullAccessResponseOpenUnauthorized() throws IOException, InterruptedException {
+            final HttpResponse<String> response = sendImageInfoRequest(OPEN_ACCESS_IMAGE, null, 2);
+            final String expectedResponse =
+                    getExpectedDescriptionResource(OPEN_ACCESS_IMAGE, FULL_ACCESS_RESPONSE_TEMPLATE_V2, 2);
+
+            Assert.assertEquals(HTTP.OK, response.statusCode());
+            TestUtils.assertEquals(expectedResponse, response.body());
+        }
+
+        @Override
+        @Test
+        public final void testFullResponseTieredAuthorized() throws IOException, InterruptedException {
+            final HttpResponse<String> response = sendImageInfoRequest(TIERED_ACCESS_IMAGE, ACCESS_TOKEN, 2);
+            final String expectedResponse =
+                    getExpectedDescriptionResource(TIERED_ACCESS_IMAGE, FULL_ACCESS_RESPONSE_TEMPLATE_V2, 2);
+
+            Assert.assertEquals(HTTP.OK, response.statusCode());
+            TestUtils.assertEquals(expectedResponse, response.body());
+        }
+
+        @Override
+        @Test
+        public final void testDegradedAccessResponseTieredUnauthorized() throws IOException, InterruptedException {
+            final HttpResponse<String> response = sendImageInfoRequest(TIERED_ACCESS_IMAGE, null, 2);
+            final String expectedResponse = getExpectedDescriptionResource(TIERED_ACCESS_IMAGE_DEGRADED_VALID,
+                    DEGRADED_ACCESS_RESPONSE_TEMPLATE_V2, 2);
+
+            Assert.assertEquals(HTTP.OK, response.statusCode());
+            TestUtils.assertEquals(expectedResponse, response.body());
+        }
+
+        @Override
+        @Test
+        public final void testErrorResponseTieredDisallowedScale() throws IOException, InterruptedException {
+            final HttpResponse<String> response =
+                    sendImageInfoRequest(TIERED_ACCESS_IMAGE_DEGRADED_UNAVAILABLE, null, 2);
+
+            Assert.assertEquals(HTTP.FORBIDDEN, response.statusCode());
+        }
+
+
+        @Override
+        @Test
+        public final void testFullAccessResponseAllOrNothingAuthorized() throws IOException, InterruptedException {
+            final HttpResponse<String> response =
+                    sendImageInfoRequest(ALL_OR_NOTHING_ACCESS_IMAGE, SINAI_ACCESS_TOKEN, 2);
+            final String expectedResponse =
+                    getExpectedDescriptionResource(ALL_OR_NOTHING_ACCESS_IMAGE, FULL_ACCESS_RESPONSE_TEMPLATE_V2, 2);
+
+            Assert.assertEquals(HTTP.OK, response.statusCode());
+            TestUtils.assertEquals(expectedResponse, response.body());
+        }
+
+        @Override
+        @Test
+        public final void testNoAccessResponseAllOrNothingUnauthorized() throws IOException, InterruptedException {
+            final HttpResponse<String> response = sendImageInfoRequest(ALL_OR_NOTHING_ACCESS_IMAGE, null, 2);
+            final String expectedResponse =
+                    getExpectedDescriptionResource(ALL_OR_NOTHING_ACCESS_IMAGE, NO_ACCESS_RESPONSE_TEMPLATE_V2, 2);
+
+            Assert.assertEquals(HTTP.UNAUTHORIZED, response.statusCode());
+            TestUtils.assertEquals(expectedResponse, response.body());
+        }
+    }
+
+    /**
+     * Tests for info.json requests via Image API 3.
+     */
+    public static class InformationRequestV3IT extends AbstractRequestIT {
+
+        @Override
+        @Test
+        public final void testFullAccessResponseOpenUnauthorized() throws IOException, InterruptedException {
+            final HttpResponse<String> response = sendImageInfoRequest(OPEN_ACCESS_IMAGE, null, 3);
+            final String expectedResponse =
+                    getExpectedDescriptionResource(OPEN_ACCESS_IMAGE, FULL_ACCESS_RESPONSE_TEMPLATE_V3, 3);
+
+            Assert.assertEquals(HTTP.OK, response.statusCode());
+            TestUtils.assertEquals(expectedResponse, response.body());
+        }
+
+        @Override
+        @Test
+        public final void testFullResponseTieredAuthorized() throws IOException, InterruptedException {
+            final HttpResponse<String> response = sendImageInfoRequest(TIERED_ACCESS_IMAGE, ACCESS_TOKEN, 3);
+            final String expectedResponse =
+                    getExpectedDescriptionResource(TIERED_ACCESS_IMAGE, FULL_ACCESS_RESPONSE_TEMPLATE_V3, 3);
+
+            Assert.assertEquals(HTTP.OK, response.statusCode());
+            TestUtils.assertEquals(expectedResponse, response.body());
+        }
+
+        @Override
+        @Test
+        public final void testDegradedAccessResponseTieredUnauthorized() throws IOException, InterruptedException {
+            final HttpResponse<String> response = sendImageInfoRequest(TIERED_ACCESS_IMAGE, null, 3);
+            final String expectedResponse = getExpectedDescriptionResource(TIERED_ACCESS_IMAGE_DEGRADED_VALID,
+                    DEGRADED_ACCESS_RESPONSE_TEMPLATE_V3, 3);
+
+            Assert.assertEquals(HTTP.OK, response.statusCode());
+            TestUtils.assertEquals(expectedResponse, response.body());
+        }
+
+        @Override
+        @Test
+        public final void testErrorResponseTieredDisallowedScale() throws IOException, InterruptedException {
+            final HttpResponse<String> response =
+                    sendImageInfoRequest(TIERED_ACCESS_IMAGE_DEGRADED_UNAVAILABLE, null, 3);
+
+            Assert.assertEquals(HTTP.FORBIDDEN, response.statusCode());
+        }
+
+        @Override
+        @Test
+        public final void testFullAccessResponseAllOrNothingAuthorized() throws IOException, InterruptedException {
+            final HttpResponse<String> response =
+                    sendImageInfoRequest(ALL_OR_NOTHING_ACCESS_IMAGE, SINAI_ACCESS_TOKEN, 3);
+            final String expectedResponse =
+                    getExpectedDescriptionResource(ALL_OR_NOTHING_ACCESS_IMAGE, FULL_ACCESS_RESPONSE_TEMPLATE_V3, 3);
+
+            Assert.assertEquals(HTTP.OK, response.statusCode());
+            TestUtils.assertEquals(expectedResponse, response.body());
+        }
+
+        @Override
+        @Test
+        public final void testNoAccessResponseAllOrNothingUnauthorized() throws IOException, InterruptedException {
+            final HttpResponse<String> response = sendImageInfoRequest(ALL_OR_NOTHING_ACCESS_IMAGE, null, 3);
+            final String expectedResponse =
+                    getExpectedDescriptionResource(ALL_OR_NOTHING_ACCESS_IMAGE, NO_ACCESS_RESPONSE_TEMPLATE_V3, 3);
+
+            Assert.assertEquals(HTTP.UNAUTHORIZED, response.statusCode());
+            TestUtils.assertEquals(expectedResponse, response.body());
+        }
+    }
 }

--- a/src/test/java/edu/ucla/library/iiif/auth/delegate/TestUtils.java
+++ b/src/test/java/edu/ucla/library/iiif/auth/delegate/TestUtils.java
@@ -4,11 +4,15 @@ package edu.ucla.library.iiif.auth.delegate;
 import static info.freelibrary.util.Constants.EMPTY;
 
 import java.io.IOException;
+import java.net.http.HttpResponse;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.TreeMap;
+import java.util.stream.Stream;
+
+import org.apache.http.HttpHeaders;
 
 import org.junit.Assert;
 
@@ -19,6 +23,8 @@ import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import info.freelibrary.iiif.presentation.v3.MediaType;
 
 /**
  * Utilities to assist with testing.
@@ -35,6 +41,19 @@ public final class TestUtils {
      */
     private TestUtils() {
         // This is intentionally left empty
+    }
+
+    /**
+     * Checks whether the response has at least one of the given content types.
+     *
+     * @param aResponse The HTTP response to test
+     * @param aMediaTypes The array of content types that the response is checked for
+     * @return Whether or not at least one of the content types is included in the response's Content-Type header
+     */
+    public static boolean responseHasContentType(final HttpResponse<?> aResponse, final MediaType... aMediaTypes) {
+        final String contentTypeHeader = aResponse.headers().firstValue(HttpHeaders.CONTENT_TYPE).get();
+
+        return Stream.of(aMediaTypes).map(String::valueOf).anyMatch(contentTypeHeader::contains);
     }
 
     /**


### PR DESCRIPTION
Much of this changeset is test refactoring, which groups each test by resource type (image or info.json) and IIIF Image API version (2 or 3). I think this makes the output more useful, and the abstract base class ensures that theres a test case for each combination of resource type and API version.


Also makes tests stronger by checking Content-Type of responses.