### PR TITLE
[SERV-371] Add access cookie service label

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,9 @@ There are some environmental properties that are supplied automatically for the 
 
     AUTH_ACCESS_SERVICE="https://example.com/access"
     AUTH_COOKIE_SERVICE="https://example.com/cookie"
+    AUTH_COOKIE_SERVICE_LABEL="UCLA Library"
     AUTH_TOKEN_SERVICE="https://example.com/token"
+    SINAI_AUTH_COOKIE_SERVICE_LABEL="Sinai Palimpsests at UCLA Library"
     SINAI_AUTH_TOKEN_SERVICE="https://example.com/token/sinai"
     TIERED_ACCESS_SCALE_CONSTRAINT="1:2"
 

--- a/pom.xml
+++ b/pom.xml
@@ -77,6 +77,10 @@
 
     <!-- Build-time options -->
     <update.sql>false</update.sql>
+
+    <!-- String constants -->
+    <access.cookie.service.label>UCLA Library</access.cookie.service.label>
+    <sinai.access.cookie.service.label>Sinai Palimpsests at UCLA Library</sinai.access.cookie.service.label>
   </properties>
 
   <dependencies>
@@ -221,9 +225,9 @@
             <!-- The Auth Access Mode Service URI will have the ID to be checked appended onto the end -->
             <AUTH_ACCESS_SERVICE>http://0.0.0.0:${test.hauth.port}/access</AUTH_ACCESS_SERVICE>
             <AUTH_COOKIE_SERVICE>http://0.0.0.0:${test.hauth.port}/cookie</AUTH_COOKIE_SERVICE>
-            <AUTH_COOKIE_SERVICE_LABEL>UCLA Library</AUTH_COOKIE_SERVICE_LABEL>
+            <AUTH_COOKIE_SERVICE_LABEL>${access.cookie.service.label}</AUTH_COOKIE_SERVICE_LABEL>
             <AUTH_TOKEN_SERVICE>http://0.0.0.0:${test.hauth.port}/token</AUTH_TOKEN_SERVICE>
-            <SINAI_AUTH_COOKIE_SERVICE_LABEL>Sinai Palimpsests at UCLA Library</SINAI_AUTH_COOKIE_SERVICE_LABEL>
+            <SINAI_AUTH_COOKIE_SERVICE_LABEL>${sinai.access.cookie.service.label}</SINAI_AUTH_COOKIE_SERVICE_LABEL>
             <SINAI_AUTH_TOKEN_SERVICE>http://0.0.0.0:${test.hauth.port}/token/sinai</SINAI_AUTH_TOKEN_SERVICE>
             <TIERED_ACCESS_SCALE_CONSTRAINT>1:2</TIERED_ACCESS_SCALE_CONSTRAINT>
           </environmentVariables>
@@ -239,9 +243,9 @@
             <!-- Test service IPs inside the containers use the Docker bridge IP address -->
             <AUTH_COOKIE_SERVICE>http://172.17.0.1:${test.hauth.port}/cookie</AUTH_COOKIE_SERVICE>
             <AUTH_TOKEN_SERVICE>http://172.17.0.1:${test.hauth.port}/token</AUTH_TOKEN_SERVICE>
-            <AUTH_COOKIE_SERVICE_LABEL>UCLA Library</AUTH_COOKIE_SERVICE_LABEL>
+            <AUTH_COOKIE_SERVICE_LABEL>${access.cookie.service.label}</AUTH_COOKIE_SERVICE_LABEL>
             <IIIF_IMAGE_URL>http://172.17.0.1:${test.iiif.images.port}</IIIF_IMAGE_URL>
-            <SINAI_AUTH_COOKIE_SERVICE_LABEL>Sinai Palimpsests at UCLA Library</SINAI_AUTH_COOKIE_SERVICE_LABEL>
+            <SINAI_AUTH_COOKIE_SERVICE_LABEL>${sinai.access.cookie.service.label}</SINAI_AUTH_COOKIE_SERVICE_LABEL>
             <SINAI_AUTH_TOKEN_SERVICE>http://172.17.0.1:${test.hauth.port}/token/sinai</SINAI_AUTH_TOKEN_SERVICE>
             <TIERED_ACCESS_SCALE_CONSTRAINT>1:2</TIERED_ACCESS_SCALE_CONSTRAINT>
           </environmentVariables>
@@ -377,9 +381,9 @@
                   <!-- The Auth Access Mode Service URI will have the ID to be checked appended onto the end -->
                   <AUTH_ACCESS_SERVICE>http://172.17.0.1:${test.hauth.port}/access</AUTH_ACCESS_SERVICE>
                   <AUTH_COOKIE_SERVICE>http://172.17.0.1:${test.hauth.port}/cookie</AUTH_COOKIE_SERVICE>
-                  <AUTH_COOKIE_SERVICE_LABEL>UCLA Library</AUTH_COOKIE_SERVICE_LABEL>
+                  <AUTH_COOKIE_SERVICE_LABEL>${access.cookie.service.label}</AUTH_COOKIE_SERVICE_LABEL>
                   <AUTH_TOKEN_SERVICE>http://172.17.0.1:${test.hauth.port}/token</AUTH_TOKEN_SERVICE>
-                  <SINAI_AUTH_COOKIE_SERVICE_LABEL>Sinai Palimpsests at UCLA Library</SINAI_AUTH_COOKIE_SERVICE_LABEL>
+                  <SINAI_AUTH_COOKIE_SERVICE_LABEL>${sinai.access.cookie.service.label}</SINAI_AUTH_COOKIE_SERVICE_LABEL>
                   <SINAI_AUTH_TOKEN_SERVICE>http://172.17.0.1:${test.hauth.port}/token/sinai</SINAI_AUTH_TOKEN_SERVICE>
                   <TIERED_ACCESS_SCALE_CONSTRAINT>1:2</TIERED_ACCESS_SCALE_CONSTRAINT>
                 </env>

--- a/pom.xml
+++ b/pom.xml
@@ -221,7 +221,9 @@
             <!-- The Auth Access Mode Service URI will have the ID to be checked appended onto the end -->
             <AUTH_ACCESS_SERVICE>http://0.0.0.0:${test.hauth.port}/access</AUTH_ACCESS_SERVICE>
             <AUTH_COOKIE_SERVICE>http://0.0.0.0:${test.hauth.port}/cookie</AUTH_COOKIE_SERVICE>
+            <AUTH_COOKIE_SERVICE_LABEL>UCLA Library</AUTH_COOKIE_SERVICE_LABEL>
             <AUTH_TOKEN_SERVICE>http://0.0.0.0:${test.hauth.port}/token</AUTH_TOKEN_SERVICE>
+            <SINAI_AUTH_COOKIE_SERVICE_LABEL>Sinai Palimpsests at UCLA Library</SINAI_AUTH_COOKIE_SERVICE_LABEL>
             <SINAI_AUTH_TOKEN_SERVICE>http://0.0.0.0:${test.hauth.port}/token/sinai</SINAI_AUTH_TOKEN_SERVICE>
             <TIERED_ACCESS_SCALE_CONSTRAINT>1:2</TIERED_ACCESS_SCALE_CONSTRAINT>
           </environmentVariables>
@@ -237,7 +239,9 @@
             <!-- Test service IPs inside the containers use the Docker bridge IP address -->
             <AUTH_COOKIE_SERVICE>http://172.17.0.1:${test.hauth.port}/cookie</AUTH_COOKIE_SERVICE>
             <AUTH_TOKEN_SERVICE>http://172.17.0.1:${test.hauth.port}/token</AUTH_TOKEN_SERVICE>
+            <AUTH_COOKIE_SERVICE_LABEL>UCLA Library</AUTH_COOKIE_SERVICE_LABEL>
             <IIIF_IMAGE_URL>http://172.17.0.1:${test.iiif.images.port}</IIIF_IMAGE_URL>
+            <SINAI_AUTH_COOKIE_SERVICE_LABEL>Sinai Palimpsests at UCLA Library</SINAI_AUTH_COOKIE_SERVICE_LABEL>
             <SINAI_AUTH_TOKEN_SERVICE>http://172.17.0.1:${test.hauth.port}/token/sinai</SINAI_AUTH_TOKEN_SERVICE>
             <TIERED_ACCESS_SCALE_CONSTRAINT>1:2</TIERED_ACCESS_SCALE_CONSTRAINT>
           </environmentVariables>
@@ -373,7 +377,9 @@
                   <!-- The Auth Access Mode Service URI will have the ID to be checked appended onto the end -->
                   <AUTH_ACCESS_SERVICE>http://172.17.0.1:${test.hauth.port}/access</AUTH_ACCESS_SERVICE>
                   <AUTH_COOKIE_SERVICE>http://172.17.0.1:${test.hauth.port}/cookie</AUTH_COOKIE_SERVICE>
+                  <AUTH_COOKIE_SERVICE_LABEL>UCLA Library</AUTH_COOKIE_SERVICE_LABEL>
                   <AUTH_TOKEN_SERVICE>http://172.17.0.1:${test.hauth.port}/token</AUTH_TOKEN_SERVICE>
+                  <SINAI_AUTH_COOKIE_SERVICE_LABEL>Sinai Palimpsests at UCLA Library</SINAI_AUTH_COOKIE_SERVICE_LABEL>
                   <SINAI_AUTH_TOKEN_SERVICE>http://172.17.0.1:${test.hauth.port}/token/sinai</SINAI_AUTH_TOKEN_SERVICE>
                   <TIERED_ACCESS_SCALE_CONSTRAINT>1:2</TIERED_ACCESS_SCALE_CONSTRAINT>
                 </env>

--- a/src/main/java/edu/ucla/library/iiif/auth/delegate/Config.java
+++ b/src/main/java/edu/ucla/library/iiif/auth/delegate/Config.java
@@ -19,6 +19,16 @@ public final class Config {
     public static final String AUTH_COOKIE_SERVICE = "AUTH_COOKIE_SERVICE";
 
     /**
+     * An environmental property for the label of the access cookie service.
+     */
+    public static final String AUTH_COOKIE_SERVICE_LABEL = "AUTH_COOKIE_SERVICE_LABEL";
+
+    /**
+     * An environmental property for the label of the Sinai access cookie service.
+     */
+    public static final String SINAI_AUTH_COOKIE_SERVICE_LABEL = "SINAI_AUTH_COOKIE_SERVICE_LABEL";
+
+    /**
      * An environmental property for the URI of the access token service.
      */
     public static final String AUTH_TOKEN_SERVICE = "AUTH_TOKEN_SERVICE";
@@ -46,6 +56,16 @@ public final class Config {
     private URI myCookieService;
 
     /**
+     * A configured cookie service label.
+     */
+    private String myCookieServiceLabel;
+
+    /**
+     * A configured Sinai cookie service label.
+     */
+    private String mySinaiCookieServiceLabel;
+
+    /**
      * A configured token service.
      */
     private URI myTokenService;
@@ -71,6 +91,9 @@ public final class Config {
     public Config() {
         setScaleConstraint(getString(Config.TIERED_ACCESS_SCALE_CONSTRAINT));
 
+        myCookieServiceLabel = getString(Config.AUTH_COOKIE_SERVICE_LABEL);
+        mySinaiCookieServiceLabel = getString(Config.SINAI_AUTH_COOKIE_SERVICE_LABEL);
+
         myCookieService = getURI(Config.AUTH_COOKIE_SERVICE);
         myTokenService = getURI(Config.AUTH_TOKEN_SERVICE);
         mySinaiTokenService = getURI(Config.SINAI_AUTH_TOKEN_SERVICE);
@@ -81,14 +104,20 @@ public final class Config {
      * Creates a new configuration.
      *
      * @param aCookieService A cookie service URI
+     * @param aCookieServiceLabel A cookie service label
+     * @param aSinaiCookieServiceLabel A Sinai cookie service label
      * @param aTokenService A token service URI
      * @param aSinaiTokenService A Sinai token service URI
      * @param aAccessService An access mode service URI
      * @param aScaleConstraint A scale constraint for tiered access
      */
-    public Config(final URI aCookieService, final URI aTokenService, final URI aSinaiTokenService,
-            final URI aAccessService, final String aScaleConstraint) {
+    public Config(final URI aCookieService, final String aCookieServiceLabel, final String aSinaiCookieServiceLabel,
+            final URI aTokenService, final URI aSinaiTokenService, final URI aAccessService,
+            final String aScaleConstraint) {
         setScaleConstraint(aScaleConstraint);
+
+        myCookieServiceLabel = aCookieServiceLabel;
+        mySinaiCookieServiceLabel = aSinaiCookieServiceLabel;
 
         myCookieService = aCookieService;
         myTokenService = aTokenService;
@@ -113,6 +142,46 @@ public final class Config {
      */
     public Config setCookieService(final URI aCookieService) {
         myCookieService = aCookieService;
+        return this;
+    }
+
+    /**
+     * Gets the configured cookie service label.
+     *
+     * @return The configured cookie service label
+     */
+    public String getCookieServiceLabel() {
+        return myCookieServiceLabel;
+    }
+
+    /**
+     * Sets the cookie service label.
+     *
+     * @param aCookieServiceLabel A label
+     * @return This configuration
+     */
+    public Config setCookieServiceLabel(final String aCookieServiceLabel) {
+        myCookieServiceLabel = aCookieServiceLabel;
+        return this;
+    }
+
+    /**
+     * Gets the configured Sinai cookie service label.
+     *
+     * @return The configured Sinai cookie service label
+     */
+    public String getSinaiCookieServiceLabel() {
+        return mySinaiCookieServiceLabel;
+    }
+
+    /**
+     * Sets the Sinai cookie service label.
+     *
+     * @param aSinaiCookieServiceLabel A label
+     * @return This configuration
+     */
+    public Config setSinaiCookieServiceLabel(final String aSinaiCookieServiceLabel) {
+        mySinaiCookieServiceLabel = aSinaiCookieServiceLabel;
         return this;
     }
 

--- a/src/main/java/edu/ucla/library/iiif/auth/delegate/HauthDelegate.java
+++ b/src/main/java/edu/ucla/library/iiif/auth/delegate/HauthDelegate.java
@@ -261,12 +261,14 @@ public class HauthDelegate extends CantaloupeDelegate implements JavaDelegate {
         switch (myAccessMode) {
             case TIERED:
                 tokenService = new AuthTokenService1(myConfig.getTokenService());
-                cookieService = new AuthCookieService1(Profile.KIOSK, myConfig.getCookieService(), null, tokenService);
+                cookieService = new AuthCookieService1(Profile.KIOSK, myConfig.getCookieService(),
+                        myConfig.getCookieServiceLabel(), tokenService);
                 break;
             case ALL_OR_NOTHING:
                 tokenService = new AuthTokenService1(myConfig.getSinaiTokenService());
                 // Cf. https://github.com/ksclarke/jiiify-presentation/issues/155
-                cookieService = new AuthCookieService1(Profile.EXTERNAL, "http://example.com", null, tokenService);
+                cookieService = new AuthCookieService1(Profile.EXTERNAL, "http://example.com",
+                        myConfig.getSinaiCookieServiceLabel(), tokenService);
                 break;
             case OPEN:
             default:

--- a/src/test/java/edu/ucla/library/iiif/auth/delegate/ConfigTest.java
+++ b/src/test/java/edu/ucla/library/iiif/auth/delegate/ConfigTest.java
@@ -25,6 +25,7 @@ public class ConfigTest {
     @Before
     public final void setUp() {
         final String fakeService = "https://example.com/service";
+        final String fakeServiceLabel = "UCLA Library";
         final URI fakeServiceURI;
 
         try {
@@ -33,7 +34,8 @@ public class ConfigTest {
             throw new ConfigException(details, fakeService);
         }
 
-        myConfig = new Config(fakeServiceURI, fakeServiceURI, fakeServiceURI, fakeServiceURI, "1:2");
+        myConfig = new Config(fakeServiceURI, fakeServiceLabel, fakeServiceLabel, fakeServiceURI, fakeServiceURI,
+                fakeServiceURI, "1:2");
     }
 
     /**
@@ -62,15 +64,19 @@ public class ConfigTest {
     @Test
     public final void testConfigUriUriUriUriString() {
         final URI cookieService = Config.getURI(Config.AUTH_COOKIE_SERVICE);
+        final String cookieServiceLabel = Config.getString(Config.AUTH_COOKIE_SERVICE_LABEL);
+        final String sinaiCookieServiceLabel = Config.getString(Config.SINAI_AUTH_COOKIE_SERVICE_LABEL);
         final URI tokenService = Config.getURI(Config.AUTH_TOKEN_SERVICE);
         final URI sinaiTokenService = Config.getURI(Config.SINAI_AUTH_TOKEN_SERVICE);
         final URI accessService = Config.getURI(Config.AUTH_ACCESS_SERVICE);
         final String scaleConstraint = Config.getString(Config.TIERED_ACCESS_SCALE_CONSTRAINT);
-        final Config config =
-                new Config(cookieService, tokenService, sinaiTokenService, accessService, scaleConstraint);
+        final Config config = new Config(cookieService, cookieServiceLabel, sinaiCookieServiceLabel, tokenService,
+                sinaiTokenService, accessService, scaleConstraint);
         final int[] scaleConstraints = config.getScaleConstraint();
 
         assertEquals(cookieService, config.getCookieService());
+        assertEquals(cookieServiceLabel, config.getCookieServiceLabel());
+        assertEquals(sinaiCookieServiceLabel, config.getSinaiCookieServiceLabel());
         assertEquals(tokenService, config.getTokenService());
         assertEquals(sinaiTokenService, config.getSinaiTokenService());
         assertEquals(accessService, config.getAccessService());
@@ -88,6 +94,25 @@ public class ConfigTest {
     public final void testSetCookieService() {
         final URI cookieService = Config.getURI(Config.AUTH_COOKIE_SERVICE);
         assertEquals(cookieService, myConfig.setCookieService(cookieService).getCookieService());
+    }
+
+    /**
+     * Tests getting/setting the cookie service label configuration.
+     */
+    @Test
+    public final void testSetCookieServiceLabel() {
+        final String cookieServiceLabel = Config.getString(Config.AUTH_COOKIE_SERVICE_LABEL);
+        assertEquals(cookieServiceLabel, myConfig.setCookieServiceLabel(cookieServiceLabel).getCookieServiceLabel());
+    }
+
+    /**
+     * Tests getting/setting the Sinai cookie service label configuration.
+     */
+    @Test
+    public final void testSetSinaiCookieServiceLabel() {
+        final String sinaiCookieServiceLabel = Config.getString(Config.SINAI_AUTH_COOKIE_SERVICE_LABEL);
+        assertEquals(sinaiCookieServiceLabel,
+                myConfig.setSinaiCookieServiceLabel(sinaiCookieServiceLabel).getSinaiCookieServiceLabel());
     }
 
     /**

--- a/src/test/java/edu/ucla/library/iiif/auth/delegate/HauthDelegateIT.java
+++ b/src/test/java/edu/ucla/library/iiif/auth/delegate/HauthDelegateIT.java
@@ -245,11 +245,13 @@ public class HauthDelegateIT {
 
         if (aResponseTemplate.equals(DEGRADED_ACCESS_RESPONSE_TEMPLATE_V2) ||
                 aResponseTemplate.equals(DEGRADED_ACCESS_RESPONSE_TEMPLATE_V3)) {
-            // The Hauth service URLs need to be added to the info.json
+            // The Hauth service URLs (and cookie service label) need to be added to the info.json
             responseTemplateURLs.add(envProperties.get(Config.AUTH_COOKIE_SERVICE));
+            responseTemplateURLs.add(envProperties.get(Config.AUTH_COOKIE_SERVICE_LABEL));
             responseTemplateURLs.add(envProperties.get(Config.AUTH_TOKEN_SERVICE));
         } else if (aResponseTemplate.equals(NO_ACCESS_RESPONSE_TEMPLATE_V2) ||
                 aResponseTemplate.equals(NO_ACCESS_RESPONSE_TEMPLATE_V3)) {
+            responseTemplateURLs.add(envProperties.get(Config.SINAI_AUTH_COOKIE_SERVICE_LABEL));
             responseTemplateURLs.add(envProperties.get(Config.SINAI_AUTH_TOKEN_SERVICE));
         }
 

--- a/src/test/resources/json/test-degraded-access-v2-info.json
+++ b/src/test/resources/json/test-degraded-access-v2-info.json
@@ -77,6 +77,7 @@
     "@context": "http://iiif.io/api/auth/1/context.json",
     "@id": "{}",
     "@type": "AuthCookieService1",
+    "label": "{}",
     "profile": "http://iiif.io/api/auth/1/kiosk",
     "service": [
       {

--- a/src/test/resources/json/test-degraded-access-v3-info.json
+++ b/src/test/resources/json/test-degraded-access-v3-info.json
@@ -69,6 +69,7 @@
       "@context": "http://iiif.io/api/auth/1/context.json",
       "@id": "{}",
       "@type": "AuthCookieService1",
+      "label": "{}",
       "profile": "http://iiif.io/api/auth/1/kiosk",
       "service": [
         {

--- a/src/test/resources/json/test-no-access-v2-info.json
+++ b/src/test/resources/json/test-no-access-v2-info.json
@@ -82,6 +82,7 @@
     "@context": "http://iiif.io/api/auth/1/context.json",
     "@id": "http://example.com",
     "@type": "AuthCookieService1",
+    "label": "{}",
     "profile": "http://iiif.io/api/auth/1/external",
     "service": [
       {

--- a/src/test/resources/json/test-no-access-v3-info.json
+++ b/src/test/resources/json/test-no-access-v3-info.json
@@ -74,6 +74,7 @@
       "@context": "http://iiif.io/api/auth/1/context.json",
       "@id": "http://example.com",
       "@type": "AuthCookieService1",
+      "label": "{}",
       "profile": "http://iiif.io/api/auth/1/external",
       "service": [
         {


### PR DESCRIPTION
`label` is a required property according to https://iiif.io/api/auth/1.0/#service-description.