### PR TITLE
[SERV-376] Validate access cookie on tiered access image requests

### DIFF
--- a/src/test/java/edu/ucla/library/iiif/auth/delegate/HauthDelegateIT.java
+++ b/src/test/java/edu/ucla/library/iiif/auth/delegate/HauthDelegateIT.java
@@ -550,7 +550,6 @@ public class HauthDelegateIT {
         }
 
         @Override
-        @Test
         public void testFullAccessResponseTieredAuthorized() throws IOException, InterruptedException {
             final HttpResponse<byte[]> response = sendImageRequest(TIERED_ACCESS_IMAGE, ACCESS_TOKEN, 2);
             final byte[] expectedResponse = getExpectedImage(TIERED_ACCESS_IMAGE);
@@ -561,7 +560,6 @@ public class HauthDelegateIT {
         }
 
         @Override
-        @Test
         public void testDegradedAccessResponseTieredUnauthorized() throws IOException, InterruptedException {
             final HttpResponse<byte[]> response = sendImageRequest(TIERED_ACCESS_IMAGE, null, 2);
 
@@ -570,7 +568,6 @@ public class HauthDelegateIT {
         }
 
         @Override
-        @Test
         public void testErrorResponseTieredDisallowedScale() throws IOException, InterruptedException {
             final HttpResponse<byte[]> response = sendImageRequest(TIERED_ACCESS_IMAGE_DEGRADED_UNAVAILABLE, null, 2);
 
@@ -615,7 +612,6 @@ public class HauthDelegateIT {
         }
 
         @Override
-        @Test
         public void testFullAccessResponseTieredAuthorized() throws IOException, InterruptedException {
             final HttpResponse<byte[]> response = sendImageRequest(TIERED_ACCESS_IMAGE, ACCESS_TOKEN, 3);
             final byte[] expectedResponse = getExpectedImage(TIERED_ACCESS_IMAGE);
@@ -626,7 +622,6 @@ public class HauthDelegateIT {
         }
 
         @Override
-        @Test
         public void testDegradedAccessResponseTieredUnauthorized() throws IOException, InterruptedException {
             final HttpResponse<byte[]> response = sendImageRequest(TIERED_ACCESS_IMAGE, null, 3);
 
@@ -635,7 +630,6 @@ public class HauthDelegateIT {
         }
 
         @Override
-        @Test
         public void testErrorResponseTieredDisallowedScale() throws IOException, InterruptedException {
             final HttpResponse<byte[]> response = sendImageRequest(TIERED_ACCESS_IMAGE_DEGRADED_UNAVAILABLE, null, 3);
 

--- a/src/test/java/edu/ucla/library/iiif/auth/delegate/HauthDelegateIT.java
+++ b/src/test/java/edu/ucla/library/iiif/auth/delegate/HauthDelegateIT.java
@@ -98,12 +98,6 @@ public class HauthDelegateIT {
             "5AFF80488740353F8A11B99C7A493D871807521908500772B92E4F8FC919E305A607ADB714B22EF08D2C22FC08C8A6EC";
 
     /**
-     * The Cookie header template for Sinai image requests.
-     */
-    private static final String SINAI_COOKIE_REQUEST_HEADER_TEMPLATE =
-            "sinai_authenticated_3day={}; initialization_vector={}";
-
-    /**
      * The id of the non-restricted image.
      */
     private static final String OPEN_ACCESS_IMAGE = "test-open.tif";
@@ -244,6 +238,16 @@ public class HauthDelegateIT {
 
         return HTTP_CLIENT.send(requestBuilder.build(), BodyHandlers.ofString()) //
                 .headers().firstValue("Set-Cookie").get();
+    }
+
+    /**
+     * Obtains an access cookie header to use in image requests for all-or-nothing access items.
+     *
+     * @return The access cookie header
+     */
+    private static String getSinaiAccessCookieHeader() {
+        return StringUtils.format("sinai_authenticated_3day={}; initialization_vector={}",
+                TEST_SINAI_AUTHENTICATED_3DAY, TEST_INITIALIZATION_VECTOR);
     }
 
     /**
@@ -598,9 +602,8 @@ public class HauthDelegateIT {
 
         @Override
         public void testFullAccessResponseAllOrNothingAuthorized() throws IOException, InterruptedException {
-            final String cookieHeader = StringUtils.format(SINAI_COOKIE_REQUEST_HEADER_TEMPLATE,
-                    TEST_SINAI_AUTHENTICATED_3DAY, TEST_INITIALIZATION_VECTOR);
-            final HttpResponse<byte[]> response = sendImageRequest(ALL_OR_NOTHING_ACCESS_IMAGE, cookieHeader, 2);
+            final HttpResponse<byte[]> response =
+                    sendImageRequest(ALL_OR_NOTHING_ACCESS_IMAGE, getSinaiAccessCookieHeader(), 2);
             final byte[] expectedResponse = getExpectedImage(ALL_OR_NOTHING_ACCESS_IMAGE);
 
             assertEquals(HTTP.OK, response.statusCode());
@@ -660,9 +663,8 @@ public class HauthDelegateIT {
 
         @Override
         public void testFullAccessResponseAllOrNothingAuthorized() throws IOException, InterruptedException {
-            final String cookieHeader = StringUtils.format(SINAI_COOKIE_REQUEST_HEADER_TEMPLATE,
-                    TEST_SINAI_AUTHENTICATED_3DAY, TEST_INITIALIZATION_VECTOR);
-            final HttpResponse<byte[]> response = sendImageRequest(ALL_OR_NOTHING_ACCESS_IMAGE, cookieHeader, 3);
+            final HttpResponse<byte[]> response =
+                    sendImageRequest(ALL_OR_NOTHING_ACCESS_IMAGE, getSinaiAccessCookieHeader(), 3);
             final byte[] expectedResponse = getExpectedImage(ALL_OR_NOTHING_ACCESS_IMAGE);
 
             assertEquals(HTTP.OK, response.statusCode());

--- a/src/test/resources/db/authzdb.sql
+++ b/src/test/resources/db/authzdb.sql
@@ -89,7 +89,8 @@ test-all-or-nothing.tif,2
 -- Name: origins; Type: TABLE DATA; Schema: public; Owner: postgres
 --
 
-COPY public.origins (url, degraded_allowed) FROM stdin;
+COPY public.origins (url, degraded_allowed) FROM stdin WITH DELIMITER ',';
+https://client.example.com,TRUE
 \.
 
 --


### PR DESCRIPTION
There is now a decent amount of duplicate code between the two access modes (e.g. hasSinaiAffiliateCookies and hasCampusNetworkCookie are basically the same), so a refactor may be in order.