### PR TITLE
[SERV-391] Redirect unauthorized tiered access image request to degraded

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,4 +60,5 @@ jobs:
           maven_profiles: default
           maven_args: >
             -V -ntp -Dorg.slf4j.simpleLogger.log.net.sourceforge.pmd=error -Ddocker.showLogs=true
+            -Ddocker.username=${{ secrets.DOCKER_USERNAME }} -Ddocker.password=${{ secrets.DOCKER_PASSWORD }}
             -Dsnyk.skip=${{ secrets.SKIP_SNYK }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,5 +72,6 @@ jobs:
           maven_args: >
             -Drevision=${{ github.event.release.tag_name }} -DautoReleaseAfterClose=${{ env.AUTORELEASE_ARTIFACT }}
             -ntp -Dorg.slf4j.simpleLogger.log.net.sourceforge.pmd=error -Ddocker.showLogs=true
+            -Ddocker.username=${{ secrets.DOCKER_USERNAME }} -Ddocker.password=${{ secrets.DOCKER_PASSWORD }}
             -DskipNexusStagingDeployMojo=${{ env.SKIP_JAR_DEPLOYMENT }}
 

--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ There is a two step build process. First, to install the cantaloupe jar in your 
 
     mvn validate
 
-After that is done, you can run the following to build the delegate:
+After that is done, you can run the following to build the delegate (Docker credentials are required to pull the `cantaloupe-ucla` image for testing):
 
-    mvn verify
+    mvn verify -Ddocker.username=username -Ddocker.password=password
 
 This will run tests of the delegate and provide a Jar file to use with your v5 Cantaloupe installation.
 
@@ -30,7 +30,7 @@ There are unit and integration tests. The integration tests spin up Docker conta
 
 An alternative to running the test containers as a part of the integration test suite is to run them directly. To do this, one would type:
 
-    mvn package docker:build docker:run -Dmaven.test.skip
+    mvn package docker:build docker:run -Dmaven.test.skip -Ddocker.username=username -Ddocker.password=password
 
 To find out which host ports the containers are running on, look for output in the Maven console logs that looks like:
 
@@ -44,7 +44,7 @@ Those port numbers can be used, in conjunction with the localhost host name, to 
 
 It's also possible to override one (or more) of these values from the command line (if you don't want to look the port number of a particular service each time you restart). To do this, you'd type:
 
-    mvn package docker:build docker:run -Dtest.iiif.images.port=8888
+    mvn package docker:build docker:run -Dtest.iiif.images.port=8888 -Ddocker.username=username -Ddocker.password=password
 
 Once all manual testing is completed, the containers can be stopped by typing: [ctrl]-C.
 
@@ -64,7 +64,7 @@ There are some environmental properties that are supplied automatically for the 
 
 To deploy a SNAPSHOT version of the delegate, run the following (with the proper credentials in your Maven settings.xml file):
 
-    mvn deploy -Drevision=0.0.1
+    mvn deploy -Drevision=0.0.1 -Ddocker.username=username -Ddocker.password=password
 
 To use the deployed Jar file with a [docker-cantaloupe](https://github.com/uclalibrary/docker-cantaloupe) container, supply the Maven repository location of the delegate via the DELEGATE_URL.
 

--- a/lib/cantaloupe-5.0.4.jar
+++ b/lib/cantaloupe-5.0.4.jar
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:234565487a25479f352140817af9b748f7b53af85c964a6857c08e6d6f98542e
-size 84840703

--- a/lib/cantaloupe-5.0.5.jar
+++ b/lib/cantaloupe-5.0.5.jar
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5116521d82f4f8798856fe6f96dd6c64f5b97df3c0b4ee5bdba1e74abb7ee7e9
+size 84816280

--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
     <!-- Dependency versions -->
     <jiiify.presentation.version>0.10.1</jiiify.presentation.version>
     <freelib.utils.version>3.0.1</freelib.utils.version>
-    <cantaloupe.version>5.0.4</cantaloupe.version>
+    <cantaloupe.version>5.0.5</cantaloupe.version>
 
     <!-- Plugin versions -->
     <shade.plugin.version>3.2.4</shade.plugin.version>
@@ -73,7 +73,7 @@
     <hauth.container.version>0.0.4</hauth.container.version>
     <psql.container.version>12.7-alpine</psql.container.version>
     <redis.container.version>6.2.5-alpine</redis.container.version>
-    <cantaloupe.container.version>nightly</cantaloupe.container.version>
+    <cantaloupe.container.version>5.0.5</cantaloupe.container.version>
 
     <!-- Build-time options -->
     <update.sql>false</update.sql>
@@ -355,7 +355,7 @@
               </run>
             </delegate_hauth>
             <delegate_cantaloupe>
-              <name>uclalibrary/cantaloupe:${cantaloupe.container.version}</name>
+              <name>uclalibrary/cantaloupe-ucla:${cantaloupe.container.version}</name>
               <run>
                 <containerNamePattern>delegate_hauth_cantaloupe</containerNamePattern>
                 <ports>

--- a/src/test/java/edu/ucla/library/iiif/auth/delegate/HauthDelegateIT.java
+++ b/src/test/java/edu/ucla/library/iiif/auth/delegate/HauthDelegateIT.java
@@ -114,6 +114,11 @@ public class HauthDelegateIT {
             StringUtils.format("test-tiered.tif;{}", System.getenv().get(Config.TIERED_ACCESS_SCALE_CONSTRAINT));
 
     /**
+     * The filename of the image identified by {@link TIERED_ACCESS_IMAGE_DEGRADED_VALID}.
+     */
+    private static final String TIERED_ACCESS_IMAGE_DEGRADED = "test-tiered-degraded.tif";
+
+    /**
      * The id of the restricted image at a degraded access tier that is not allowed.
      */
     private static final String TIERED_ACCESS_IMAGE_DEGRADED_UNAVAILABLE = "test-tiered.tif;3:4";
@@ -587,9 +592,11 @@ public class HauthDelegateIT {
         @Override
         public void testDegradedAccessResponseTieredUnauthorized() throws IOException, InterruptedException {
             final HttpResponse<byte[]> response = sendImageRequest(TIERED_ACCESS_IMAGE, null, 2);
+            final byte[] expectedResponse = getExpectedImage(TIERED_ACCESS_IMAGE_DEGRADED);
 
-            assertEquals(HTTP.UNAUTHORIZED, response.statusCode());
-            assertFalse(TestUtils.responseHasContentType(response, MediaType.IMAGE_TIFF));
+            assertEquals(HTTP.OK, response.statusCode());
+            assertTrue(TestUtils.responseHasContentType(response, MediaType.IMAGE_TIFF));
+            assertTrue(Arrays.equals(expectedResponse, response.body()));
         }
 
         @Override
@@ -648,9 +655,11 @@ public class HauthDelegateIT {
         @Override
         public void testDegradedAccessResponseTieredUnauthorized() throws IOException, InterruptedException {
             final HttpResponse<byte[]> response = sendImageRequest(TIERED_ACCESS_IMAGE, null, 3);
+            final byte[] expectedResponse = getExpectedImage(TIERED_ACCESS_IMAGE_DEGRADED);
 
-            assertEquals(HTTP.UNAUTHORIZED, response.statusCode());
-            assertFalse(TestUtils.responseHasContentType(response, MediaType.IMAGE_TIFF));
+            assertEquals(HTTP.OK, response.statusCode());
+            assertTrue(TestUtils.responseHasContentType(response, MediaType.IMAGE_TIFF));
+            assertTrue(Arrays.equals(expectedResponse, response.body()));
         }
 
         @Override

--- a/src/test/resources/images/test-tiered-degraded.tif
+++ b/src/test/resources/images/test-tiered-degraded.tif
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fbb021a0f02c7fa171326ae64a9bc9b8cb949acbf036fa808932970bca8b85a8
+size 1148827


### PR DESCRIPTION
Unauthorized tiered access image requests will now result in a 302 redirect to a degraded version, rather than a 401.

I anticipate that the GitHub Actions build will result in failing tests of the 401 responses for _information_ requests, since the response JSON schema has recently changed in the Cantaloupe upstream. My hope is that that change is reverted at some point, but the question of what to do in the meantime with the failing tests remains.