### PR TITLE
[SERV-473] Respect X-Forwarded-For header

### DIFF
--- a/src/main/resources/auth-delegate_messages.xml
+++ b/src/main/resources/auth-delegate_messages.xml
@@ -34,5 +34,6 @@
   <entry key="CAD-026">Generated cookies: {}={}, {}={} (cleartext: "{}")</entry>
   <entry key="CAD-027">Access allowed: Degraded image request for the size we allow</entry>
   <entry key="CAD-028">Access denied: Degraded image request for a size we don't allow: {}:{}</entry>
+  <entry key="CAD-029">Request header "{}" not found</entry>
 
 </properties>


### PR DESCRIPTION
In order to work when Cantaloupe is deployed behind a reverse proxy, the delegate script needs to pass along the X-Forwarded-For header in its requests to Hauth's token service, since the iiif-access cookie contains an IP address that will only be found in that header. Passing it along to the Sinai token service isn't strictly necessary, but I figured it can't hurt.