### PR TITLE
Allow access to all thumbnails, regardless of auth

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,6 +76,8 @@
 
     <!-- Build-time options -->
     <update.sql>false</update.sql>
+    <skipUTs>false</skipUTs>
+    <skipITs>false</skipITs>
   </properties>
 
   <dependencies>
@@ -138,6 +140,7 @@
       <!-- Install Cantaloupe, which isn't distributed through Maven Central -->
       <plugin>
         <artifactId>maven-install-plugin</artifactId>
+        <groupId>org.apache.maven.plugins</groupId>
         <executions>
           <execution>
             <id>install-cantaloupe</id>
@@ -224,6 +227,7 @@
             <SINAI_AUTH_TOKEN_SERVICE>http://0.0.0.0:${test.hauth.port}/token/sinai</SINAI_AUTH_TOKEN_SERVICE>
             <TIERED_ACCESS_SCALE_CONSTRAINT>1:2</TIERED_ACCESS_SCALE_CONSTRAINT>
           </environmentVariables>
+          <skipTests>${skipUTs}</skipTests>
         </configuration>
       </plugin>
       <plugin>
@@ -240,6 +244,7 @@
             <SINAI_AUTH_TOKEN_SERVICE>http://172.17.0.1:${test.hauth.port}/token/sinai</SINAI_AUTH_TOKEN_SERVICE>
             <TIERED_ACCESS_SCALE_CONSTRAINT>1:2</TIERED_ACCESS_SCALE_CONSTRAINT>
           </environmentVariables>
+          <skipTests>${skipITs}</skipTests>
         </configuration>
       </plugin>
       <plugin>

--- a/src/main/java/edu/ucla/library/iiif/auth/delegate/HauthDelegate.java
+++ b/src/main/java/edu/ucla/library/iiif/auth/delegate/HauthDelegate.java
@@ -130,7 +130,6 @@ public class HauthDelegate extends CantaloupeDelegate implements JavaDelegate {
      * this point in time.
      */
     @Override
-    @SuppressWarnings("PMD.SystemPrintln")
     public Object preAuthorize() {
         final JavaContext context = getContext();
         final String id = context.getIdentifier();

--- a/src/main/java/edu/ucla/library/iiif/auth/delegate/HauthDelegate.java
+++ b/src/main/java/edu/ucla/library/iiif/auth/delegate/HauthDelegate.java
@@ -22,7 +22,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import info.freelibrary.util.HTTP;
 import info.freelibrary.util.Logger;
 import info.freelibrary.util.LoggerFactory;
-
 import info.freelibrary.iiif.presentation.v3.services.AuthCookieService1;
 import info.freelibrary.iiif.presentation.v3.services.AuthTokenService1;
 import info.freelibrary.iiif.presentation.v3.services.ExternalCookieService1;
@@ -34,7 +33,7 @@ import edu.ucla.library.iiif.auth.delegate.hauth.AccessMode;
 import edu.ucla.library.iiif.auth.delegate.hauth.HauthItem;
 import edu.ucla.library.iiif.auth.delegate.hauth.HauthSinaiToken;
 import edu.ucla.library.iiif.auth.delegate.hauth.HauthToken;
-
+import edu.illinois.library.cantaloupe.delegate.JavaContext;
 import edu.illinois.library.cantaloupe.delegate.JavaDelegate;
 
 /**
@@ -51,6 +50,11 @@ public class HauthDelegate extends CantaloupeDelegate implements JavaDelegate {
      * A Jackson TypeReference for a Map.
      */
     private static final TypeReference<Map<String, Object>> MAP_TYPE_REFERENCE = new TypeReference<>() {};
+
+    /**
+     * The default thumbnail dimensions.
+     */
+    private static final String THUMBNAIL_DIMS = "/!200,200/";
 
     /**
      * The name of the Cookie HTTP request header.
@@ -126,9 +130,18 @@ public class HauthDelegate extends CantaloupeDelegate implements JavaDelegate {
      * this point in time.
      */
     @Override
+    @SuppressWarnings("PMD.SystemPrintln")
     public Object preAuthorize() {
+        final JavaContext context = getContext();
+        final String id = context.getIdentifier();
+
+        // We let all thumbnail requests through regardless of authorization
+        if (context.getLocalURI().contains(THUMBNAIL_DIMS)) {
+            return true;
+        }
+
         // Cache the result of the access level HTTP request
-        myAccessMode = new HauthItem(myConfig.getAccessService(), getContext().getIdentifier()).getAccessMode();
+        myAccessMode = new HauthItem(myConfig.getAccessService(), id).getAccessMode();
 
         switch (myAccessMode) {
             case OPEN:

--- a/src/test/java/edu/ucla/library/iiif/auth/delegate/HauthDelegateIT.java
+++ b/src/test/java/edu/ucla/library/iiif/auth/delegate/HauthDelegateIT.java
@@ -194,7 +194,6 @@ public class HauthDelegateIT {
      * Tests that thumbnails of access controlled items are still displayed.
      */
     @Test
-    @SuppressWarnings("PMD.SystemPrintln")
     public final void testAccessControlledThumbnails() throws InterruptedException, IOException {
         final String imageURL =
                 StringUtils.format(IMAGE_URL_TEMPLATE, System.getenv().get(TestConfig.IIIF_URL_PROPERTY), 2,

--- a/src/test/java/edu/ucla/library/iiif/auth/delegate/HauthDelegateIT.java
+++ b/src/test/java/edu/ucla/library/iiif/auth/delegate/HauthDelegateIT.java
@@ -5,6 +5,8 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
@@ -17,6 +19,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+
+import javax.imageio.ImageIO;
 
 import org.apache.commons.io.FileUtils;
 import org.junit.Test;
@@ -185,6 +189,29 @@ public class HauthDelegateIT {
      */
     private static final HttpClient HTTP_CLIENT =
             HttpClient.newBuilder().followRedirects(Redirect.NORMAL).version(HttpClient.Version.HTTP_1_1).build();
+
+    /**
+     * Tests that thumbnails of access controlled items are still displayed.
+     */
+    @Test
+    @SuppressWarnings("PMD.SystemPrintln")
+    public final void testAccessControlledThumbnails() throws InterruptedException, IOException {
+        final String imageURL =
+                StringUtils.format(IMAGE_URL_TEMPLATE, System.getenv().get(TestConfig.IIIF_URL_PROPERTY), 2,
+                        ALL_OR_NOTHING_ACCESS_IMAGE + "/full/!200,200/0/default.tif");
+        final HttpRequest.Builder requestBuilder = HttpRequest.newBuilder(URI.create(imageURL));
+        final HttpResponse<byte[]> response = HTTP_CLIENT.send(requestBuilder.build(), BodyHandlers.ofByteArray());
+        final ByteArrayInputStream byteArrayInputStream;
+        final BufferedImage image;
+
+        assertEquals(200, response.statusCode());
+
+        byteArrayInputStream = new ByteArrayInputStream(response.body());
+        image = ImageIO.read(byteArrayInputStream);
+
+        assertEquals(200, image.getHeight());
+        assertEquals(200, image.getWidth());
+    }
 
     /******************
      * Helper methods *


### PR DESCRIPTION
* Add options to skip all unit and integration tests for targetted testing
* Allow access to all thumbnails, regardless of items' auth restrictions