### PR TITLE
[SERV-1197] Fix Hauth ENVs in test container configs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,7 +57,6 @@ jobs:
         uses: samuelmeuli/action-maven-publish@201a45a3f311b2ee888f252ba9f4194257545709 # v1.4.0
         with:
           maven_goals_phases: "clean verify"
-          maven_profiles: default
           maven_args: >
             -V -ntp -Dorg.slf4j.simpleLogger.log.net.sourceforge.pmd=error -Ddocker.showLogs=true
             -Ddocker.username=${{ secrets.DOCKER_USERNAME }} -Ddocker.password=${{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
       UCLALIBRARY_SNYK_ORG: ${{ secrets.UCLALIBRARY_SNYK_ORG }}
     strategy:
       matrix:
-        java: [ 11 ]
+        java: [ 17 ]
 
     steps:
       - name: Set up build cache

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   publish:
-    name: Maven Artifact Publisher (JDK 11)
+    name: Maven Artifact Publisher (JDK 17)
     runs-on: ubuntu-latest
     env:
       AUTORELEASE_ARTIFACT: ${{ secrets.AUTORELEASE_ARTIFACT }}
@@ -29,11 +29,11 @@ jobs:
           lfs: true
       - name: Checkout LFS objects
         run: git lfs checkout
-      - name: Install JDK 11
+      - name: Install JDK 17
         uses: actions/setup-java@8764a52df183aa0ccea74521dfd9d506ffc7a19a # v2
         with:
           distribution: 'adopt'
-          java-version: 11
+          java-version: 17
       # If running locally in act, install Maven
       - name: Set up Maven if needed
         if: ${{ env.ACT }}
@@ -73,7 +73,7 @@ jobs:
             -Drevision=${{ github.event.release.tag_name }} -DautoReleaseAfterClose=${{ env.AUTORELEASE_ARTIFACT }}
             -ntp -Dorg.slf4j.simpleLogger.log.net.sourceforge.pmd=error -Ddocker.showLogs=true
             -Ddocker.username=${{ secrets.DOCKER_USERNAME }} -Ddocker.password=${{ secrets.DOCKER_PASSWORD }}
-            -DskipNexusStagingDeployMojo=${{ env.SKIP_JAR_DEPLOYMENT }}
+            -DskipNexusStagingDeployMojo=${{ env.SKIP_JAR_DEPLOYMENT }} -DskipTests
       - name: Publish Jar Artifact to S3
         uses: jakejarvis/s3-sync-action@be0c4ab89158cac4278689ebedd8407dd5f35a83 # v0.5.1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,7 +73,7 @@ jobs:
             -Drevision=${{ github.event.release.tag_name }} -DautoReleaseAfterClose=${{ env.AUTORELEASE_ARTIFACT }}
             -ntp -Dorg.slf4j.simpleLogger.log.net.sourceforge.pmd=error -Ddocker.showLogs=true
             -Ddocker.username=${{ secrets.DOCKER_USERNAME }} -Ddocker.password=${{ secrets.DOCKER_PASSWORD }}
-            -DskipNexusStagingDeployMojo=${{ env.SKIP_JAR_DEPLOYMENT }} -DskipTests
+            -DskipNexusStagingDeployMojo=${{ env.SKIP_JAR_DEPLOYMENT }}
       - name: Publish Jar Artifact to S3
         uses: jakejarvis/s3-sync-action@be0c4ab89158cac4278689ebedd8407dd5f35a83 # v0.5.1
         with:

--- a/pom.xml
+++ b/pom.xml
@@ -59,20 +59,20 @@
   <properties>
     <!-- Dependency versions -->
     <jiiify.presentation.version>0.12.1</jiiify.presentation.version>
-    <freelib.utils.version>3.0.1</freelib.utils.version>
+    <freelib.utils.version>5.0.7</freelib.utils.version>
     <cantaloupe.version>5.0.6</cantaloupe.version>
 
     <!-- Plugin versions -->
-    <shade.plugin.version>3.2.4</shade.plugin.version>
+    <shade.plugin.version>3.6.0</shade.plugin.version>
     <download.plugin.version>1.6.7</download.plugin.version>
     <failsafe.plugin.version>2.22.0</failsafe.plugin.version>
-    <docker.maven.plugin.version>0.37.0</docker.maven.plugin.version>
+    <docker.maven.plugin.version>0.45.1</docker.maven.plugin.version>
 
     <!-- Docker images versions used in testing -->
-    <hauth.container.version>0.0.6</hauth.container.version>
+    <hauth.container.version>0.0.7</hauth.container.version>
     <psql.container.version>12.7-alpine</psql.container.version>
     <redis.container.version>6.2.5-alpine</redis.container.version>
-    <cantaloupe.container.version>5.0.5</cantaloupe.container.version>
+    <cantaloupe.container.version>5.0.6</cantaloupe.container.version>
 
     <!-- Build-time options -->
     <update.sql>false</update.sql>
@@ -331,9 +331,9 @@
                   <DB_PASSWORD>${test.db.password}</DB_PASSWORD>
                   <DB_CACHE_PORT>${test.db.cache.port}</DB_CACHE_PORT>
                   <CAMPUS_NETWORK_SUBNETS>172.17.0.0/24,192.168.0.0/24</CAMPUS_NETWORK_SUBNETS>
-                  <SECRET_KEY_GENERATION_PASSWORD>${test.secretkey.password}</SECRET_KEY_GENERATION_PASSWORD>
-                  <SECRET_KEY_GENERATION_SALT>${test.secretkey.salt}</SECRET_KEY_GENERATION_SALT>
-                  <SINAI_COOKIE_SECRET_KEY_GENERATION_PASSWORD>ThisPasswordIsReallyHardToGuess!</SINAI_COOKIE_SECRET_KEY_GENERATION_PASSWORD>
+                  <SECRET_KEY_PASSWORD>${test.secretkey.password}</SECRET_KEY_PASSWORD>
+                  <SECRET_KEY_SALT>${test.secretkey.salt}</SECRET_KEY_SALT>
+                  <SINAI_COOKIE_SECRET_KEY_PASSWORD>ThisPasswordIsReallyHardToGuess!</SINAI_COOKIE_SECRET_KEY_PASSWORD>
                   <SINAI_COOKIE_VALID_PREFIX>Authenticated</SINAI_COOKIE_VALID_PREFIX>
                 </env>
                 <dependsOn>
@@ -504,18 +504,6 @@
                   </args>
                 </configuration>
               </execution>
-              <execution>
-                <id>snyk-monitor</id>
-                <goals>
-                  <goal>monitor</goal>
-                </goals>
-                <configuration>
-                  <args>
-                    <arg>--org=${env.UCLALIBRARY_SNYK_ORG}</arg>
-                    <arg>--fail-on=all</arg>
-                  </args>
-                </configuration>
-              </execution>
             </executions>
           </plugin>
         </plugins>
@@ -538,6 +526,6 @@
   <parent>
     <artifactId>freelib-parent</artifactId>
     <groupId>info.freelibrary</groupId>
-    <version>7.2.1</version>
+    <version>12.0.2</version>
   </parent>
 </project>

--- a/src/main/java/edu/ucla/library/iiif/auth/delegate/Config.java
+++ b/src/main/java/edu/ucla/library/iiif/auth/delegate/Config.java
@@ -69,12 +69,12 @@ public final class Config {
      * Creates a new configuration.
      */
     public Config() {
-        setScaleConstraint(getString(Config.TIERED_ACCESS_SCALE_CONSTRAINT));
+        setScaleConstraint(getString(TIERED_ACCESS_SCALE_CONSTRAINT));
 
-        myCookieService = getURI(Config.AUTH_COOKIE_SERVICE);
-        myTokenService = getURI(Config.AUTH_TOKEN_SERVICE);
-        mySinaiTokenService = getURI(Config.SINAI_AUTH_TOKEN_SERVICE);
-        myAccessService = getURI(Config.AUTH_ACCESS_SERVICE);
+        myCookieService = getURI(AUTH_COOKIE_SERVICE);
+        myTokenService = getURI(AUTH_TOKEN_SERVICE);
+        mySinaiTokenService = getURI(SINAI_AUTH_TOKEN_SERVICE);
+        myAccessService = getURI(AUTH_ACCESS_SERVICE);
     }
 
     /**
@@ -190,6 +190,7 @@ public final class Config {
      *
      * @param aScaleConstraint A scale constraint for tiered access
      * @return This configuration
+     * @throws ConfigException if there is a problem with the scale constraint's syntax
      */
     public Config setScaleConstraint(final String aScaleConstraint) {
         try {

--- a/src/main/java/edu/ucla/library/iiif/auth/delegate/HauthDelegate.java
+++ b/src/main/java/edu/ucla/library/iiif/auth/delegate/HauthDelegate.java
@@ -130,7 +130,6 @@ public class HauthDelegate extends CantaloupeDelegate implements JavaDelegate {
      * this point in time.
      */
     @Override
-    @SuppressWarnings("PMD.SystemPrintln")
     public Object preAuthorize() {
         final JavaContext context = getContext();
         final String id = context.getIdentifier();

--- a/src/main/java/edu/ucla/library/iiif/auth/delegate/HauthDelegate.java
+++ b/src/main/java/edu/ucla/library/iiif/auth/delegate/HauthDelegate.java
@@ -130,6 +130,7 @@ public class HauthDelegate extends CantaloupeDelegate implements JavaDelegate {
      * this point in time.
      */
     @Override
+    @SuppressWarnings({ "PMD.ImplicitSwitchFallThrough" })
     public Object preAuthorize() {
         final JavaContext context = getContext();
         final String id = context.getIdentifier();
@@ -492,7 +493,12 @@ public class HauthDelegate extends CantaloupeDelegate implements JavaDelegate {
      * The different types of requests that this delegate may process.
      */
     private enum RequestType {
-        INFORMATION, IMAGE;
+
+        /** An information request type. */
+        INFORMATION,
+
+        /** An image request type. */
+        IMAGE;
     }
 
     /**

--- a/src/main/java/edu/ucla/library/iiif/auth/delegate/HauthDelegate.java
+++ b/src/main/java/edu/ucla/library/iiif/auth/delegate/HauthDelegate.java
@@ -130,6 +130,7 @@ public class HauthDelegate extends CantaloupeDelegate implements JavaDelegate {
      * this point in time.
      */
     @Override
+    @SuppressWarnings("PMD.SystemPrintln")
     public Object preAuthorize() {
         final JavaContext context = getContext();
         final String id = context.getIdentifier();

--- a/src/main/java/edu/ucla/library/iiif/auth/delegate/hauth/AccessMode.java
+++ b/src/main/java/edu/ucla/library/iiif/auth/delegate/hauth/AccessMode.java
@@ -9,5 +9,13 @@ package edu.ucla.library.iiif.auth.delegate.hauth;
  *      Access-Controlled Resources </a>
  */
 public enum AccessMode {
-    OPEN, TIERED, ALL_OR_NOTHING;
+
+    /** An open access mode. */
+    OPEN,
+
+    /** A tiered access mode. */
+    TIERED,
+
+    /** An all-or-nothing access mode. */
+    ALL_OR_NOTHING;
 }

--- a/src/main/java/edu/ucla/library/iiif/auth/delegate/hauth/HauthItem.java
+++ b/src/main/java/edu/ucla/library/iiif/auth/delegate/hauth/HauthItem.java
@@ -115,6 +115,7 @@ public class HauthItem {
      * Constructs the Access Mode Service URI by appending the requested ID onto the end of the service URI's path.
      *
      * @return A URI for the access mode service with the requested ID included
+     * @throws ConfigException if there is a problem with the access service's URI
      */
     private URI getURI() {
         final URIBuilder uriBuilder = new URIBuilder(myAccessModeService);

--- a/src/main/tools/checkstyle/checkstyle-suppressions.xml
+++ b/src/main/tools/checkstyle/checkstyle-suppressions.xml
@@ -4,6 +4,6 @@
   "https://checkstyle.org/dtds/suppressions_1_2.dtd">
 
 <suppressions>
-  <suppress files="src[\\/]main[\\/]generated[\\/]" checks="."/>
-  <suppress files="target[\\/]" checks="."/>
+  <suppress files=".*\.mvn[\\/].*" checks="." />
+  <suppress files=".*docs[\\/].*" checks="." />
 </suppressions>

--- a/src/main/tools/checkstyle/checkstyle.xml
+++ b/src/main/tools/checkstyle/checkstyle.xml
@@ -44,14 +44,28 @@
     <module name="BooleanExpressionComplexity">
       <property name="max" value="4" />
     </module>
-    <module name="MissingJavadocMethod" />
+    <module name="MissingJavadocMethod">
+      <property name="scope" value="private" />
+    </module>
+    <module name="JavadocMethod">
+      <property name="validateThrows" value="true" />
+      <property name="allowedAnnotations"
+        value="Override, Test, Before, BeforeClass, After, AfterClass, JsonInclude, JsonGetter, JsonSetter, JsonProperty" />
+    </module>
     <module name="JavadocType">
       <property name="excludeScope" value="anoninner" />
-      <property name="allowUnknownTags" value="true" />
     </module>
-    <module name="MissingJavadocType" />
+    <module name="NonEmptyAtclauseDescription"/>
+    <module name="InvalidJavadocPosition"/>
+    <module name="JavadocVariable" />
     <module name="MissingJavadocPackage" />
-    <module name="JavadocMethod" />
+    <module name="SummaryJavadocCheck" />
+    <module name="MissingJavadocType">
+      <property name="scope" value="private" />
+    </module>
+    <module name="JavadocStyle">
+      <property name="checkFirstSentence" value="false"/>
+    </module>
     <module name="NeedBraces" />
     <module name="LeftCurly" />
     <module name="RightCurly" />

--- a/src/main/tools/pmd/ruleset.xml
+++ b/src/main/tools/pmd/ruleset.xml
@@ -12,11 +12,12 @@
 
   <rule ref="category/java/bestpractices.xml">
     <exclude name="GuardLogStatement" />
+    <exclude name="LooseCoupling" />
   </rule>
   <rule ref="category/java/bestpractices.xml/UnusedPrivateMethod">
     <properties>
       <property name="ignoredAnnotations"
-        value="com.fasterxml.jackson.annotation.JsonSetter|com.fasterxml.jackson.annotation.JsonGetter" />
+        value="com.fasterxml.jackson.annotation.JsonSetter,com.fasterxml.jackson.annotation.JsonGetter" />
     </properties>
   </rule>
   <rule ref="category/java/bestpractices.xml/ForLoopVariableCount">
@@ -27,12 +28,12 @@
 
   <rule ref="category/java/codestyle.xml">
     <exclude name="OnlyOneReturn" />
-    <exclude name="DefaultPackage" />
+    <exclude name="CommentDefaultAccessModifier" />
     <exclude name="CallSuperInConstructor" /> <!-- Default super is handled by default -->
     <exclude name="ConfusingTernary" /> <!-- It makes more sense to ask if something isn't null, IMHO -->
     <exclude name="PrematureDeclaration" /> <!-- Sometimes useful, but more often than not a false positive -->
-    <exclude name="AtLeastOneConstructor" />
-    <exclude name="CommentDefaultAccessModifier" />
+    <exclude name="UnnecessaryConstructor" /> <!-- Javadocs requires even default constructors to have docs -->
+    <exclude name="AtLeastOneConstructor" /> <!-- Non-public classes can have default constructors -->
   </rule>
   <rule ref="category/java/codestyle.xml/ClassNamingConventions">
     <properties>
@@ -76,7 +77,8 @@
   <rule ref="category/java/design.xml">
     <exclude name="LawOfDemeter" />
     <exclude name="LoosePackageCoupling" />
-    <exclude name="UselessOverridingMethod" />
+    <exclude name="SimplifyBooleanReturns" />
+    <exclude name="DataClass" />
   </rule>
   <rule ref="category/java/design.xml/TooManyMethods">
     <properties>
@@ -94,8 +96,8 @@
 
   <rule ref="category/java/errorprone.xml">
     <exclude name="AssignmentInOperand" />
-    <exclude name="DataflowAnomalyAnalysis" />
-    <exclude name="BeanMembersShouldSerialize" />
+    <exclude name="InvalidLogMessageFormat" />
+    <exclude name="MissingStaticMethodInNonInstantiatableClass" />
   </rule>
 
   <rule ref="category/java/performance.xml">

--- a/src/test/java/edu/ucla/library/iiif/auth/delegate/HauthDelegateIT.java
+++ b/src/test/java/edu/ucla/library/iiif/auth/delegate/HauthDelegateIT.java
@@ -26,8 +26,6 @@ import org.apache.commons.io.FileUtils;
 import org.junit.Test;
 
 import info.freelibrary.util.HTTP;
-import info.freelibrary.util.Logger;
-import info.freelibrary.util.LoggerFactory;
 import info.freelibrary.util.StringUtils;
 
 import info.freelibrary.iiif.presentation.v3.MediaType;

--- a/src/test/java/edu/ucla/library/iiif/auth/delegate/HauthDelegateIT.java
+++ b/src/test/java/edu/ucla/library/iiif/auth/delegate/HauthDelegateIT.java
@@ -40,11 +40,6 @@ import edu.ucla.library.iiif.auth.delegate.hauth.HauthToken;
 public class HauthDelegateIT {
 
     /**
-     * The HauthDelegateIT logger.
-     */
-    private static final Logger LOGGER = LoggerFactory.getLogger(HauthDelegateIT.class, MessageCodes.BUNDLE);
-
-    /**
      * The template for image URLs. The slots are:
      * <ul>
      * <li>Cantaloupe base URL</li>
@@ -84,9 +79,8 @@ public class HauthDelegateIT {
      */
     private static final String TEST_INITIALIZATION_VECTOR = "30313233343536373839414243444546";
 
-    @SuppressWarnings("checkstyle:lineLengthChecker")
     /**
-     * A test cookie generated using the following Ruby code, mocking the relevant part of the Sinai application:
+     * A test cookie generated using the following Ruby code, mocking the relevant part of the Sinai application.
      * <p>
      *
      * <pre>
@@ -101,9 +95,8 @@ public class HauthDelegateIT {
      * puts (cipher.update("Authenticated #{Time.at(0).utc}") + cipher.final).unpack("H*")[0].upcase
      * </pre>
      *
-     * @see <a href=
-     *      "https://github.com/UCLALibrary/sinaimanuscripts/blob/44cbbd9bf508c32b742f1617205a679edf77603e/app/controllers/application_controller.rb#L98-L103">How
-     *      the Sinai application encodes cookies</a>
+     * @see <a href= "https://github.com/UCLALibrary/sinaimanuscripts/blob/44cbbd9bf508c32b742f1617205a679edf77603e/app/
+     *      controllers/application_controller.rb#L98-L103">How the Sinai application encodes cookies</a>
      */
     private static final String TEST_SINAI_AUTHENTICATED_3DAY =
             "5AFF80488740353F8A11B99C7A493D871807521908500772B92E4F8FC919E305A607ADB714B22EF08D2C22FC08C8A6EC";
@@ -282,6 +275,7 @@ public class HauthDelegateIT {
      * Obtains an access cookie header to use in image requests for all-or-nothing access items.
      *
      * @return The access cookie header
+     * @throws IOException If the Sinai access cookie cannot be retrieved
      */
     private static String getSinaiAccessCookieHeader() throws IOException {
         final String[] values = TestUtils.getMockSinaiCookieValues();
@@ -374,9 +368,9 @@ public class HauthDelegateIT {
         return StringUtils.format(IMAGE_URL_TEMPLATE, aBaseURL, aImageApiVersion, imageApiPath);
     }
 
-    /*********
-     * Tests *
-     *********/
+    /*
+     * Tests
+     */
 
     /**
      * An abstract base class for testing the responses to requests for both description resources (info.json) and

--- a/src/test/java/edu/ucla/library/iiif/auth/delegate/HauthDelegateIT.java
+++ b/src/test/java/edu/ucla/library/iiif/auth/delegate/HauthDelegateIT.java
@@ -212,9 +212,9 @@ public class HauthDelegateIT {
         assertEquals(200, image.getWidth());
     }
 
-    /******************
-     * Helper methods *
-     ******************/
+    /*
+     * Helper methods
+     */
 
     /**
      * Sends an HTTP request for the description resource containing image information (info.json).

--- a/src/test/java/edu/ucla/library/iiif/auth/delegate/TestUtils.java
+++ b/src/test/java/edu/ucla/library/iiif/auth/delegate/TestUtils.java
@@ -124,6 +124,8 @@ public final class TestUtils {
      *
      * @param aExpected A first JSON string
      * @param aFound A second JSON string
+     * @throws JsonProcessingException If there is trouble processing the JSON tree
+     * @throws IOException If there is trouble reading the JSON tree
      */
     public static void assertEquals(final String aExpected, final String aFound)
             throws JsonProcessingException, IOException {
@@ -133,7 +135,7 @@ public final class TestUtils {
     /**
      * A sorting node factory.
      */
-    private static class SortingNodeFactory extends JsonNodeFactory {
+    private static final class SortingNodeFactory extends JsonNodeFactory {
 
         /**
          * The <code>serialVersionUID</code> for the sorting node factory.
@@ -157,7 +159,7 @@ public final class TestUtils {
     private static class SortedArrayNode extends ArrayNode {
 
         /**
-         * The <code>serialVersionUID</code>
+         * The <code>serialVersionUID</code> of this node.
          */
         private static final long serialVersionUID = 4000699652392697259L;
 


### PR DESCRIPTION
The main fix:

* Update the Hauth ENVs to match the latest Docker image's versions

But also:

* Update parent project, dependencies, checkstyle/PMD rules
* Remove Snyk `monitor` (left `test` still for now)
* Update JDK to 17 (to match with Hauth/Cantaloupe Docker images)
* Fixed code to conform to the latest Checkstyle/PMD rules (mostly Javadoc stuff)

TIL: You can break long URLs in Javadocs as long as you break on a slash and the whole URL is contained within quotes).